### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -25,3 +25,4 @@ jobs:
       - uses: golangci/golangci-lint-action@v3
         with:
           version: v1.53
+          args: --timeout=3m


### PR DESCRIPTION
1. Fix branch name
2. Increase golangci-lint timeout

Tested that it works on my fork (https://github.com/kolyshkin/check-payload/actions/runs/5415908130)