### PR TITLE
Remove obsoleted requirements

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,17 +30,13 @@ var applicationDeps = []string{
 	"nm",
 	"oc",
 	"podman",
-	"readelf",
-	"strings",
 }
 
 var applicationDepsNodeScan = []string{
 	"file",
 	"go",
 	"nm",
-	"readelf",
 	"rpm",
-	"strings",
 }
 
 var requiredGolangSymbols = []string{


### PR DESCRIPTION
Since commit bcbd76c48840e, readelf binary is no longer used.

Since commit 69b3c2f800341, strings binary is no longer used.