### PR TITLE
fix: use rpm name as tag in node scan

### DIFF
--- a/node_scan.go
+++ b/node_scan.go
@@ -56,7 +56,6 @@ func runNodeScan(ctx context.Context, cfg *Config) []*ScanResults {
 			if fileInfo.Mode()&os.ModeSymlink != 0 {
 				continue
 			}
-			tag = NewTag(path)
 			klog.V(1).InfoS("scanning path", "path", path)
 			res := scanBinary(ctx, component, tag, cfg.NodeScan, innerPath)
 			if res.Skip {


### PR DESCRIPTION
Currently, the node scan error report has the full file name on the host:

```
./check-payload scan node --root /some/very/long/path
.......

---- Failure Report
+----------------+--------------------------------------+------------------------------------+
| PATH           | STATUS                               | FROM                               |
+----------------+--------------------------------------+------------------------------------+
| /sbin/ldconfig | executable is not dynamically linked | /some/very/long/path/sbin/ldconfig |
+----------------+--------------------------------------+------------------------------------+
```

I think it makes more sense to use rpm name as a tag, otherwise FROM does not add any new information (it's --root argument + PATH).

With this change:
```
+----------------+--------------------------------------+--------------------------+
| PATH           | STATUS                               | FROM                     |
+----------------+--------------------------------------+--------------------------+
| /sbin/ldconfig | executable is not dynamically linked | glibc-2.37-4.fc38.x86_64 |
+----------------+--------------------------------------+--------------------------+
```