### PR TITLE
add warning support and --fail-on-warnings flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ var (
 	components                            []string
 	configFile, configForVersion          string
 	cpuProfile                            string
+	failOnWarnings                        bool
 	filterFiles, filterDirs, filterImages []string
 	insecurePull                          bool
 	limit                                 int
@@ -88,6 +89,7 @@ func main() {
 			if err := getConfig(&config); err != nil {
 				return err
 			}
+			config.FailOnWarnings = failOnWarnings
 			config.FilterFiles = append(config.FilterFiles, filterFiles...)
 			config.FilterDirs = append(config.FilterDirs, filterDirs...)
 			config.FilterImages = append(config.FilterImages, filterImages...)
@@ -125,6 +127,9 @@ func main() {
 			if isFailed(results) {
 				return errors.New("run failed")
 			}
+			if isWarnings(results) && config.FailOnWarnings {
+				return errors.New("run failed with warnings")
+			}
 			return nil
 		},
 	}
@@ -134,6 +139,7 @@ func main() {
 	scanCmd.PersistentFlags().StringSliceVar(&filterDirs, "filter-dirs", nil, "")
 	scanCmd.PersistentFlags().StringSliceVar(&filterImages, "filter-images", nil, "")
 	scanCmd.PersistentFlags().StringSliceVar(&components, "components", nil, "")
+	scanCmd.PersistentFlags().BoolVar(&failOnWarnings, "fail-on-warnings", false, "fail on warnings")
 	scanCmd.PersistentFlags().BoolVar(&insecurePull, "insecure-pull", false, "use insecure pull")
 	scanCmd.PersistentFlags().IntVar(&limit, "limit", -1, "limit the number of pods scanned")
 	scanCmd.PersistentFlags().IntVar(&parallelism, "parallelism", 5, "how many pods to check at once")

--- a/types_scan_result.go
+++ b/types_scan_result.go
@@ -25,6 +25,14 @@ func (r *ScanResult) Skipped() *ScanResult {
 	return r
 }
 
+func (r *ScanResult) IsLevel(level ErrorLevel) bool {
+	return r.Error != nil && r.Error.Level == level
+}
+
+func (r *ScanResult) IsSuccess() bool {
+	return r.Error == nil
+}
+
 func (r *ScanResult) SetOpenssl(info OpensslInfo) *ScanResult {
 	if !info.Present {
 		r.SetError(errors.New("openssl library not present"))
@@ -35,8 +43,13 @@ func (r *ScanResult) SetOpenssl(info OpensslInfo) *ScanResult {
 	return r
 }
 
-func (r *ScanResult) SetError(err error) *ScanResult {
+func (r *ScanResult) SetValidationError(err *ValidationError) *ScanResult {
 	r.Error = err
+	return r
+}
+
+func (r *ScanResult) SetError(err error) *ScanResult {
+	r.Error = NewValidationError(err)
 	return r
 }
 

--- a/validations.go
+++ b/validations.go
@@ -37,7 +37,7 @@ type Baton struct {
 	GoVersionDetailed []byte
 }
 
-type ValidationFn func(ctx context.Context, tag *v1.TagReference, path string, baton *Baton) error
+type ValidationFn func(ctx context.Context, tag *v1.TagReference, path string, baton *Baton) *ValidationError
 
 var validationFns = map[string][]ValidationFn{
 	"go": {
@@ -54,27 +54,27 @@ var validationFns = map[string][]ValidationFn{
 	},
 }
 
-func validateGoVersion(ctx context.Context, _ *v1.TagReference, path string, baton *Baton) error {
+func validateGoVersion(ctx context.Context, _ *v1.TagReference, path string, baton *Baton) *ValidationError {
 	var stdout bytes.Buffer
 	cmd := exec.CommandContext(ctx, "go", "version", "-m", path)
 	cmd.Stdout = &stdout
 	if err := cmd.Run(); err != nil {
-		return err
+		return NewValidationError(err)
 	}
 
 	matches := validateGoVersionRegexp.FindAllStringSubmatch(stdout.String(), -1)
 	if len(matches) == 0 {
-		return fmt.Errorf("go: could not find compiler version in binary")
+		return NewValidationError(fmt.Errorf("go: could not find compiler version in binary"))
 	}
 	baton.GoVersion = matches[0][1]
 	baton.GoVersionDetailed = stdout.Bytes()
 	return nil
 }
 
-func validateGoSymbols(_ context.Context, _ *v1.TagReference, path string, baton *Baton) error {
+func validateGoSymbols(_ context.Context, _ *v1.TagReference, path string, baton *Baton) *ValidationError {
 	symtable, err := readTable(path)
 	if err != nil {
-		return fmt.Errorf("go: could not read table for %v: %w", filepath.Base(path), err)
+		return NewValidationError(fmt.Errorf("go: could not read table for %v: %w", filepath.Base(path), err))
 	}
 	// Skip if the golang binary is not using crypto
 	if !isUsingCryptoModule(symtable) {
@@ -84,18 +84,18 @@ func validateGoSymbols(_ context.Context, _ *v1.TagReference, path string, baton
 
 	v, err := semver.NewVersion(baton.GoVersion)
 	if err != nil {
-		return fmt.Errorf("go: error creating semver version: %w", err)
+		return NewValidationError(fmt.Errorf("go: error creating semver version: %w", err))
 	}
 	c, err := semver.NewConstraint("< 1.18")
 	if err != nil {
-		return fmt.Errorf("go: error creating semver constraint: %w", err)
+		return NewValidationError(fmt.Errorf("go: error creating semver constraint: %w", err))
 	}
 	if c.Check(v) {
 		return nil
 	}
 
 	if err := ExpectedSyms(requiredGolangSymbols, symtable); err != nil {
-		return fmt.Errorf("go: expected symbols not found for %v: %w", filepath.Base(path), err)
+		return NewValidationError(fmt.Errorf("go: expected symbols not found for %v: %w", filepath.Base(path), err))
 	}
 	return nil
 }
@@ -109,36 +109,36 @@ func isUsingCryptoModule(symtable *gosym.Table) bool {
 	return false
 }
 
-func validateGoCgo(_ context.Context, _ *v1.TagReference, _ string, baton *Baton) error {
+func validateGoCgo(_ context.Context, _ *v1.TagReference, _ string, baton *Baton) *ValidationError {
 	v, err := semver.NewVersion(baton.GoVersion)
 	if err != nil {
-		return fmt.Errorf("go: error creating semver version: %w", err)
+		return NewValidationError(fmt.Errorf("go: error creating semver version: %w", err))
 	}
 	c, err := semver.NewConstraint("<= 1.17")
 	if err != nil {
-		return fmt.Errorf("go: error creating semver constraint: %w", err)
+		return NewValidationError(fmt.Errorf("go: error creating semver constraint: %w", err))
 	}
 	if c.Check(v) {
 		return nil
 	}
 
 	if !bytes.Contains(baton.GoVersionDetailed, []byte("CGO_ENABLED=1")) {
-		return fmt.Errorf("go: binary is not CGO_ENABLED")
+		return NewValidationError(fmt.Errorf("go: binary is not CGO_ENABLED"))
 	}
 	return nil
 }
 
-func validateGoTags(_ context.Context, _ *v1.TagReference, _ string, baton *Baton) error {
+func validateGoTags(_ context.Context, _ *v1.TagReference, _ string, baton *Baton) *ValidationError {
 	invalidTagsSet := mapset.NewSet("no_openssl")
 	expectedTagsSet := mapset.NewSet("strictfipsruntime")
 
 	v, err := semver.NewVersion(baton.GoVersion)
 	if err != nil {
-		return fmt.Errorf("go: error creating semver version: %w", err)
+		return NewValidationError(fmt.Errorf("go: error creating semver version: %w", err))
 	}
 	c, err := semver.NewConstraint("<= 1.17")
 	if err != nil {
-		return fmt.Errorf("go: error creating semver constraint: %w", err)
+		return NewValidationError(fmt.Errorf("go: error creating semver constraint: %w", err))
 	}
 	if c.Check(v) {
 		return nil
@@ -151,24 +151,24 @@ func validateGoTags(_ context.Context, _ *v1.TagReference, _ string, baton *Bato
 
 	tags := strings.Split(string(matches[0][1]), ",")
 	if len(tags) == 0 {
-		return nil
+		return NewValidationError(fmt.Errorf("go: binary has zero tags enabled (should have strictfipsruntime)")).SetWarning()
 	}
 
 	// check for invalid tags
 	binaryTags := mapset.NewSet(tags...)
 	if set := binaryTags.Intersect(invalidTagsSet); set.Cardinality() > 0 {
-		return fmt.Errorf("go: binary has invalid tag %v enabled", set.ToSlice())
+		return NewValidationError(fmt.Errorf("go: binary has invalid tag %v enabled", set.ToSlice()))
 	}
 
 	// check for required tags
 	if set := binaryTags.Intersect(expectedTagsSet); set.Cardinality() == 0 {
-		return fmt.Errorf("go: binary does not contain required tag(s) %v", expectedTagsSet.ToSlice())
+		return NewValidationError(fmt.Errorf("go: binary does not contain required tag(s) %v", expectedTagsSet.ToSlice())).SetWarning()
 	}
 
 	return nil
 }
 
-func validateGoStatic(ctx context.Context, _ *v1.TagReference, path string, baton *Baton) error {
+func validateGoStatic(ctx context.Context, _ *v1.TagReference, path string, baton *Baton) *ValidationError {
 	// if the static golang binary does not contain crypto then skip
 	if baton.GoNoCrypto {
 		return nil
@@ -178,19 +178,19 @@ func validateGoStatic(ctx context.Context, _ *v1.TagReference, path string, bato
 	return validateStaticGo(ctx, path)
 }
 
-func validateGoOpenssl(_ context.Context, _ *v1.TagReference, path string, baton *Baton) error {
+func validateGoOpenssl(_ context.Context, _ *v1.TagReference, path string, baton *Baton) *ValidationError {
 	// if there is no crypto then skip openssl test
 	if baton.GoNoCrypto {
 		return nil
 	}
 	// check for openssl strings
-	return validateStringsOpenssl(path, baton)
+	return NewValidationError(validateStringsOpenssl(path, baton))
 }
 
-func validateGoCGOInit(_ context.Context, _ *v1.TagReference, path string, _ *Baton) error {
+func validateGoCGOInit(_ context.Context, _ *v1.TagReference, path string, _ *Baton) *ValidationError {
 	f, err := os.Open(path)
 	if err != nil {
-		return err
+		return NewValidationError(err)
 	}
 	defer f.Close()
 
@@ -203,7 +203,7 @@ func validateGoCGOInit(_ context.Context, _ *v1.TagReference, path string, _ *Ba
 	for {
 		n, err := stream.Read(buf)
 		if err != nil && err != io.EOF {
-			return err
+			return NewValidationError(err)
 		}
 		if n == 0 || err == io.EOF {
 			break
@@ -215,7 +215,7 @@ func validateGoCGOInit(_ context.Context, _ *v1.TagReference, path string, _ *Ba
 	}
 
 	if !cgoInitFound {
-		return fmt.Errorf("x_cgo_init: not found")
+		return NewValidationError(fmt.Errorf("x_cgo_init: not found"))
 	}
 
 	return nil
@@ -278,24 +278,24 @@ func validateStringsOpenssl(path string, baton *Baton) error {
 	return nil
 }
 
-func validateStaticGo(ctx context.Context, path string) error {
+func validateStaticGo(ctx context.Context, path string) *ValidationError {
 	return isDynamicallyLinked(ctx, path)
 }
 
-func isDynamicallyLinked(ctx context.Context, path string) error {
+func isDynamicallyLinked(ctx context.Context, path string) *ValidationError {
 	var stdout bytes.Buffer
 	cmd := exec.CommandContext(ctx, "file", "-s", path)
 	cmd.Stdout = &stdout
 	if err := cmd.Run(); err != nil {
-		return err
+		return NewValidationError(err)
 	}
 	if !bytes.Contains(stdout.Bytes(), []byte("dynamically linked")) {
-		return fmt.Errorf("exe: executable is statically linked")
+		return NewValidationError(fmt.Errorf("exe: executable is statically linked"))
 	}
 	return nil
 }
 
-func validateExe(ctx context.Context, _ *v1.TagReference, path string, _ *Baton) error {
+func validateExe(ctx context.Context, _ *v1.TagReference, path string, _ *Baton) *ValidationError {
 	return isDynamicallyLinked(ctx, path)
 }
 
@@ -361,7 +361,7 @@ func scanBinary(ctx context.Context, component *OpenshiftComponent, tag *v1.TagR
 
 	for _, fn := range allFn {
 		if err := fn(ctx, tag, path, baton); err != nil {
-			return res.SetError(err)
+			return res.SetValidationError(err)
 		}
 	}
 
@@ -369,14 +369,14 @@ func scanBinary(ctx context.Context, component *OpenshiftComponent, tag *v1.TagR
 	if isGoExecutable(ctx, path) == nil {
 		for _, fn := range goFn {
 			if err := fn(ctx, tag, path, baton); err != nil {
-				return res.SetError(err)
+				return res.SetValidationError(err)
 			}
 		}
 	} else {
 		// is a regular binary
 		for _, fn := range exeFn {
 			if err := fn(ctx, tag, path, baton); err != nil {
-				return res.SetError(err)
+				return res.SetValidationError(err)
 			}
 		}
 	}


### PR DESCRIPTION
Changes strictfipsruntime flag to be a warning and adds warning error support to the application.

Additionally adds `--fail-on-warnings` flag to preserve warnings as errors.