### PR TITLE
feat: ensure the config is fully parsed

### DIFF
--- a/dist/releases/4.9/config.toml
+++ b/dist/releases/4.9/config.toml
@@ -24,6 +24,9 @@ filter_files = [
   "/sbin/ldconfig",
 ]
 
+# List of images to ignore.
+filter_images = [ ]
+
 # these node exceptions via rpm have been manually validated
 [node."cri-o-1.22.5-20.rhaos4.9.gitdf6ec18.el8.x86_64"]
 filter_files = [
@@ -38,9 +41,6 @@ filter_files = [ "/usr/bin/pinns" ]
 
 [node."podman-catatonit-3.2.3-0.12.module+el8.4.0+14908+81312c48.x86_64"]
 filter_files = [ "/usr/libexec/catatonit/catatonit" ]
-
-# List of images to ignore.
-filter_images = [ ]
 
 # Payload Components
 

--- a/main.go
+++ b/main.go
@@ -220,7 +220,23 @@ func main() {
 	}
 }
 
-func getConfig(config *types.Config) error {
+func getConfig(config *types.Config) (retErr error) {
+	var (
+		res toml.MetaData
+		err error
+	)
+
+	// Check if the configuration was fully parsed.
+	defer func() {
+		if retErr != nil {
+			return
+		}
+		un := res.Undecoded()
+		if len(un) != 0 {
+			retErr = fmt.Errorf("unknown keys in config: %+v", un)
+		}
+	}()
+
 	// Handle --config-for-version first.
 	if configForVersion != "" {
 		if configFile != "" {
@@ -230,7 +246,7 @@ func getConfig(config *types.Config) error {
 		if err != nil {
 			return err
 		}
-		_, err = toml.Decode(string(cfg), &config)
+		res, err = toml.Decode(string(cfg), &config)
 		if err != nil { // Should never happen.
 			panic("invalid embedded config: " + err.Error())
 		}
@@ -242,7 +258,7 @@ func getConfig(config *types.Config) error {
 	if file == "" {
 		file = defaultConfigFile
 	}
-	_, err := toml.DecodeFile(file, &config)
+	res, err = toml.DecodeFile(file, &config)
 	if err == nil {
 		klog.Infof("using config file: %v", file)
 		return nil
@@ -252,7 +268,7 @@ func getConfig(config *types.Config) error {
 	// defaultConfigFile is not found, fall back to embedded config.
 	if errors.Is(err, os.ErrNotExist) && configFile == "" {
 		klog.Info("using embedded config")
-		_, err = toml.Decode(embeddedConfig, &config)
+		res, err = toml.Decode(embeddedConfig, &config)
 		if err != nil { // Should never happen.
 			panic("invalid embedded config: " + err.Error())
 		}


### PR DESCRIPTION
Return an error otherwise.

This actually helped to find an error in 4.9 config (which is fixed). Before the fix, the error looked like this:

> Error: unknown keys in config: [node."podman-catatonit-3.2.3-0.12.module+el8.4.0+14908+81312c48.x86_64".filter_images]

_this used to be part of #33_