### PR TITLE
fix: log the entire configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.19
 require (
 	github.com/BurntSushi/toml v1.3.2
 	github.com/Masterminds/semver/v3 v3.2.1
-	github.com/carlmjohnson/versioninfo v0.22.4
 	github.com/deckarep/golang-set/v2 v2.3.0
 	github.com/jedib0t/go-pretty/v6 v6.4.6
 	github.com/openshift/api v0.0.0-20230120195050-6ba31fa438f2

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,6 @@ github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8n
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/butuzov/ireturn v0.1.1/go.mod h1:Wh6Zl3IMtTpaIKbmwzqi6olnM9ptYQxxVacMsOEFPoc=
-github.com/carlmjohnson/versioninfo v0.22.4 h1:AucUHDSKmk6j7Yx3dECGUxaowGHOAN0Zx5/EBtsXn4Y=
-github.com/carlmjohnson/versioninfo v0.22.4/go.mod h1:QT9mph3wcVfISUKd0i9sZfVrPviHuSF+cUtLjm2WSf8=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=

--- a/internal/types/types_config.go
+++ b/internal/types/types_config.go
@@ -3,31 +3,12 @@ package types
 import (
 	"strings"
 
-	"github.com/carlmjohnson/versioninfo"
 	imagev1 "github.com/openshift/api/image/v1"
 	"k8s.io/klog/v2"
 )
 
 func (c *Config) Log() {
-	klog.InfoS("using config",
-		"components", c.Components,
-		"filter_dirs", c.FilterDirs,
-		"filter_files", c.FilterFiles,
-		"filter_images", c.FilterImages,
-		"from_file", c.FromFile,
-		"from_url", c.FromURL,
-		"limit", c.Limit,
-		"node_scan", c.NodeScan,
-		"container_image", c.ContainerImage,
-		"payload_ignores", c.PayloadIgnores,
-		"node_ignores", c.NodeIgnores,
-		"output_file", c.OutputFile,
-		"output_format", c.OutputFormat,
-		"parallelism", c.Parallelism,
-		"time_limit", c.TimeLimit,
-		"verbose", c.Verbose,
-		"version", versioninfo.Revision,
-	)
+	klog.Infof("using config +%v", c)
 }
 
 // isMatch tells if path equals to one of the entries.


### PR DESCRIPTION
Some fields are now missing from the log. Generally, it is not very realistic to keep the Log function in sync with the configuration.

The solution is to use %+v which will print all the fields.

While at it, do not print git commit since we already do better than that in main.go (right after calling config.Log()).

(_this used to be a part of #33_)