### PR TITLE
ExpectedSyms: document, refactor, return bool

### DIFF
--- a/internal/golang/goscan.go
+++ b/internal/golang/goscan.go
@@ -98,18 +98,12 @@ func ReadTable(fileName string) (*gosym.Table, error) {
 	return symTable, nil
 }
 
-// Checks the .gopclntab for the expected list of symbols.
-func ExpectedSyms(expectedSyms []string, symTable *gosym.Table) error {
-	found := false
-	for _, s := range expectedSyms {
-		fn := symTable.LookupFunc(s)
-		if fn != nil {
-			found = true
-			break
+// ExpectedSyms checks that .gopclntab contains any of the expectedSymbols.
+func ExpectedSyms(expectedSymbols []string, symTable *gosym.Table) bool {
+	for _, s := range expectedSymbols {
+		if symTable.LookupFunc(s) != nil {
+			return true
 		}
 	}
-	if !found {
-		return fmt.Errorf("expected symbol(s) %v not found", expectedSyms)
-	}
-	return nil
+	return false
 }

--- a/internal/validations/validations.go
+++ b/internal/validations/validations.go
@@ -102,8 +102,8 @@ func validateGoSymbols(_ context.Context, _ *v1.TagReference, path string, baton
 		return nil
 	}
 
-	if err := golang.ExpectedSyms(requiredGolangSymbols, symtable); err != nil {
-		return types.NewValidationError(fmt.Errorf("go: expected symbols not found for %v: %w", filepath.Base(path), err))
+	if !golang.ExpectedSyms(requiredGolangSymbols, symtable) {
+		return types.NewValidationError(fmt.Errorf("go: expected symbols not found for %v", filepath.Base(path)))
 	}
 	return nil
 }


### PR DESCRIPTION
1. Document that we are looking for ANY of the expected symbols.

2. Simplify the code.

3. Return bool instead of an error. This avoid wrapping errors.

_this used to be part of #33_