### PR TITLE
fix: properly log config

### DIFF
--- a/internal/types/types_config.go
+++ b/internal/types/types_config.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (c *Config) Log() {
-	klog.Infof("using config +%v", c)
+	klog.Infof("using config %+v", c)
 }
 
 // isMatch tells if path equals to one of the entries.


### PR DESCRIPTION
There was a typo in commit daa9119be15768dd6f6b / PR #54 

Fixes: daa9119be15768dd6f6bb3a216062e715aa42740