### PR TITLE
optimize using regular expressions

### DIFF
--- a/internal/validations/validations.go
+++ b/internal/validations/validations.go
@@ -77,11 +77,11 @@ func validateGoVersion(ctx context.Context, path string, baton *Baton) *types.Va
 }
 
 func doValidateGoVersion(stdout *bytes.Buffer, baton *Baton) *types.ValidationError {
-	matches := validateGoVersionRegexp.FindAllStringSubmatch(stdout.String(), -1)
-	if len(matches) == 0 {
+	matches := validateGoVersionRegexp.FindSubmatch(stdout.Bytes())
+	if len(matches) < 2 {
 		return types.NewValidationError(fmt.Errorf("go: could not find compiler version in binary"))
 	}
-	ver := matches[0][1]
+	ver := string(matches[1])
 	semver, err := semver.NewVersion(ver)
 	if err != nil {
 		return types.NewValidationError(fmt.Errorf("can't parse go version %q: %w", ver, err))

--- a/internal/validations/validations.go
+++ b/internal/validations/validations.go
@@ -73,6 +73,10 @@ func validateGoVersion(ctx context.Context, path string, baton *Baton) *types.Va
 		return types.NewValidationError(err)
 	}
 
+	return doValidateGoVersion(&stdout, baton)
+}
+
+func doValidateGoVersion(stdout *bytes.Buffer, baton *Baton) *types.ValidationError {
 	matches := validateGoVersionRegexp.FindAllStringSubmatch(stdout.String(), -1)
 	if len(matches) == 0 {
 		return types.NewValidationError(fmt.Errorf("go: could not find compiler version in binary"))

--- a/internal/validations/validations.go
+++ b/internal/validations/validations.go
@@ -137,12 +137,12 @@ func validateGoTags(_ context.Context, _ string, baton *Baton) *types.Validation
 		return nil
 	}
 
-	matches := validateGoTagsRegexp.FindAllSubmatch(baton.GoVersionDetailed, -1)
-	if matches == nil {
+	matches := validateGoTagsRegexp.FindSubmatch(baton.GoVersionDetailed)
+	if len(matches) < 2 {
 		return types.NewValidationError(fmt.Errorf("go: binary has zero tags enabled (should have strictfipsruntime)")).SetWarning()
 	}
 
-	tags := strings.Split(string(matches[0][1]), ",")
+	tags := strings.Split(string(matches[1]), ",")
 	if len(tags) == 0 {
 		return types.NewValidationError(fmt.Errorf("go: binary has zero tags enabled (should have strictfipsruntime)")).SetWarning()
 	}

--- a/internal/validations/validations.go
+++ b/internal/validations/validations.go
@@ -237,11 +237,7 @@ func validateStringsOpenssl(path string, baton *Baton) error {
 			break
 		}
 
-		matches := validateStringsOpensslRegexp.FindAllSubmatch(buf, -1)
-		if len(matches) == 0 {
-			continue
-		}
-		binaryLibcryptoVersion := string(matches[0][0])
+		binaryLibcryptoVersion := string(validateStringsOpensslRegexp.Find(buf))
 		if binaryLibcryptoVersion == "" {
 			continue
 		}
@@ -249,7 +245,7 @@ func validateStringsOpenssl(path string, baton *Baton) error {
 			// Have different libcrypto versions in the same binary.
 			haveMultipleLibcrypto = true
 		}
-		libcryptoVersion = string(matches[0][0])
+		libcryptoVersion = binaryLibcryptoVersion
 	}
 
 	if libcryptoVersion == "" {

--- a/internal/validations/validations_test.go
+++ b/internal/validations/validations_test.go
@@ -1,12 +1,32 @@
 package validations
 
 import (
-	"context"
+	"bytes"
 	"testing"
 )
 
-func TestEXE(t *testing.T) {
-	if err := validateExe(context.Background(), "/usr/bin/lua5.1", nil); err != nil {
-		t.Fatal(err)
+const testGoVersionDetailed = `/usr/bin/runc: go1.19.9
+	path	github.com/opencontainers/runc
+	build	-compiler=gc
+	build	-ldflags="-X main.gitCommit= -X main.version=1.1.6 -linkmode=external -compressdwarf=false -B 0x0bfd31e9756ba9e517cb946d2b1c23012b6919ed -extldflags '-Wl,-z,relro  -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld'"
+	build	-tags=rpm_crashtraceback,libtrust_openssl,selinux,seccomp,strictfipsruntime
+	build	CGO_ENABLED=1
+	build	CGO_CFLAGS="-O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64"
+	build	CGO_CPPFLAGS=
+	build	CGO_CXXFLAGS=
+	build	CGO_LDFLAGS=
+	build	GOARCH=amd64
+	build	GOOS=linux
+	build	GOAMD64=v1`
+
+func BenchmarkValidateGoVersion(b *testing.B) {
+	baton := &Baton{}
+	out := bytes.NewBuffer([]byte(testGoVersionDetailed))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := doValidateGoVersion(out, baton); err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/internal/validations/validations_test.go
+++ b/internal/validations/validations_test.go
@@ -2,6 +2,7 @@ package validations
 
 import (
 	"bytes"
+	"context"
 	"testing"
 )
 
@@ -26,6 +27,24 @@ func BenchmarkValidateGoVersion(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if err := doValidateGoVersion(out, baton); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkValidateGoTags(b *testing.B) {
+	ctx := context.Background()
+	path := "/usr/bin/runc"
+	baton := &Baton{}
+	out := bytes.NewBuffer([]byte(testGoVersionDetailed))
+	if err := doValidateGoVersion(out, baton); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i <= b.N; i++ {
+		err := validateGoTags(ctx, path, baton)
+		if err != nil {
 			b.Fatal(err)
 		}
 	}


### PR DESCRIPTION
Also
 - add some benchmarks;
 - use substring matching instead of mapset for checking go build tags.

See individual commits for details.