### PR TITLE
rpm-related refactoring and cleanups

### DIFF
--- a/dist/releases/4.10/config.toml
+++ b/dist/releases/4.10/config.toml
@@ -27,13 +27,13 @@ filter_files = [
 filter_images = [ ]
 
 # these node exceptions via rpm have been manually validated
-[rpm."glibc-2.28-151.el8.x86_64"]
+[rpm.glibc]
 filter_files = [ "/sbin/ldconfig" ]
 
-[rpm."cri-o-1.23.5-16.rhaos4.10.gitbb2cc9a.el8.x86_64"]
+[rpm.cri-o]
 filter_files = [ "/usr/bin/pinns" ]
 
-[rpm."podman-catatonit-3.2.3-0.12.module+el8.4.0+14908+81312c48.x86_64"]
+[rpm.podman-catatonit]
 filter_files = [ "/usr/libexec/catatonit/catatonit" ]
 
 # Payload Components

--- a/dist/releases/4.10/config.toml
+++ b/dist/releases/4.10/config.toml
@@ -27,13 +27,13 @@ filter_files = [
 filter_images = [ ]
 
 # these node exceptions via rpm have been manually validated
-[node."glibc-2.28-151.el8.x86_64"]
+[rpm."glibc-2.28-151.el8.x86_64"]
 filter_files = [ "/sbin/ldconfig" ]
 
-[node."cri-o-1.23.5-16.rhaos4.10.gitbb2cc9a.el8.x86_64"]
+[rpm."cri-o-1.23.5-16.rhaos4.10.gitbb2cc9a.el8.x86_64"]
 filter_files = [ "/usr/bin/pinns" ]
 
-[node."podman-catatonit-3.2.3-0.12.module+el8.4.0+14908+81312c48.x86_64"]
+[rpm."podman-catatonit-3.2.3-0.12.module+el8.4.0+14908+81312c48.x86_64"]
 filter_files = [ "/usr/libexec/catatonit/catatonit" ]
 
 # Payload Components

--- a/dist/releases/4.11/config.toml
+++ b/dist/releases/4.11/config.toml
@@ -28,48 +28,48 @@ filter_images = [ ]
 
 # Node Ignores
 # these node exceptions via rpm have been manually validated
-[rpm."glibc-2.28-189.5.el8_6.x86_64"]
+[rpm.glibc]
 filter_files = [
   "/sbin/ldconfig"
 ]
 
-[rpm."ignition-2.14.0-5.rhaos4.11.el8.x86_64"]
+[rpm.ignition]
 filter_files = [
   "/usr/lib/dracut/modules.d/30ignition/ignition"
 ]
 
-[rpm."skopeo-1.5.2-4.rhaos4.11.el8.x86_64"]
+[rpm.skopeo]
 filter_files = [
   "/usr/bin/skopeo"
 ]
 
-[rpm."podman-catatonit-4.0.2-7.rhaos4.11.el8.x86_64"]
+[rpm.podman-catatonit]
 filter_files = [
   "/usr/libexec/catatonit/catatonit"
 ]
 
-[rpm."runc-1.1.2-2.rhaos4.11.el8.x86_64"]
+[rpm.runc]
 filter_files = [
   "/usr/bin/runc"
 ]
 
-[rpm."cri-o-1.24.6-2.rhaos4.11.git4bfe15a.el8.x86_64"]
+[rpm.cri]
 filter_files = [
   "/usr/bin/crio",
   "/usr/bin/crio-status",
   "/usr/bin/pinns",
 ]
 
-[rpm."cri-tools-1.24.2-7.el8.x86_64"]
+[rpm.cri-tools]
 filter_files = [ "/usr/bin/crictl" ]
 
-[rpm."podman-4.0.2-7.rhaos4.11.el8.x86_64"]
+[rpm.podman]
 filter_Files = [
   "/usr/bin/podman",
   "/usr/libexec/podman/rootlessport",
 ]
 
-[rpm."containernetworking-plugins-1.0.1-6.rhaos4.11.el8.x86_64"]
+[rpm.containernetworking-plugins]
 filter_files = [
   "/usr/libexec/cni/bandwidth",
   "/usr/libexec/cni/bridge",

--- a/dist/releases/4.11/config.toml
+++ b/dist/releases/4.11/config.toml
@@ -28,48 +28,48 @@ filter_images = [ ]
 
 # Node Ignores
 # these node exceptions via rpm have been manually validated
-[node."glibc-2.28-189.5.el8_6.x86_64"]
+[rpm."glibc-2.28-189.5.el8_6.x86_64"]
 filter_files = [
   "/sbin/ldconfig"
 ]
 
-[node."ignition-2.14.0-5.rhaos4.11.el8.x86_64"]
+[rpm."ignition-2.14.0-5.rhaos4.11.el8.x86_64"]
 filter_files = [
   "/usr/lib/dracut/modules.d/30ignition/ignition"
 ]
 
-[node."skopeo-1.5.2-4.rhaos4.11.el8.x86_64"]
+[rpm."skopeo-1.5.2-4.rhaos4.11.el8.x86_64"]
 filter_files = [
   "/usr/bin/skopeo"
 ]
 
-[node."podman-catatonit-4.0.2-7.rhaos4.11.el8.x86_64"]
+[rpm."podman-catatonit-4.0.2-7.rhaos4.11.el8.x86_64"]
 filter_files = [
   "/usr/libexec/catatonit/catatonit"
 ]
 
-[node."runc-1.1.2-2.rhaos4.11.el8.x86_64"]
+[rpm."runc-1.1.2-2.rhaos4.11.el8.x86_64"]
 filter_files = [
   "/usr/bin/runc"
 ]
 
-[node."cri-o-1.24.6-2.rhaos4.11.git4bfe15a.el8.x86_64"]
+[rpm."cri-o-1.24.6-2.rhaos4.11.git4bfe15a.el8.x86_64"]
 filter_files = [
   "/usr/bin/crio",
   "/usr/bin/crio-status",
   "/usr/bin/pinns",
 ]
 
-[node."cri-tools-1.24.2-7.el8.x86_64"]
+[rpm."cri-tools-1.24.2-7.el8.x86_64"]
 filter_files = [ "/usr/bin/crictl" ]
 
-[node."podman-4.0.2-7.rhaos4.11.el8.x86_64"]
+[rpm."podman-4.0.2-7.rhaos4.11.el8.x86_64"]
 filter_Files = [
   "/usr/bin/podman",
   "/usr/libexec/podman/rootlessport",
 ]
 
-[node."containernetworking-plugins-1.0.1-6.rhaos4.11.el8.x86_64"]
+[rpm."containernetworking-plugins-1.0.1-6.rhaos4.11.el8.x86_64"]
 filter_files = [
   "/usr/libexec/cni/bandwidth",
   "/usr/libexec/cni/bridge",

--- a/dist/releases/4.12/config.toml
+++ b/dist/releases/4.12/config.toml
@@ -28,44 +28,44 @@ filter_images = [ ]
 
 # Node Ignores
 # these node exceptions via rpm have been manually validated
-[node."runc-1.1.6-4.rhaos4.12.el8.x86_64"]
+[rpm."runc-1.1.6-4.rhaos4.12.el8.x86_64"]
 filter_files = [ "/usr/bin/runc" ]
 
-[node."cri-tools-1.25.0-2.el8.x86_64"]
+[rpm."cri-tools-1.25.0-2.el8.x86_64"]
 filter_files = [ "/usr/bin/crictl" ]
 
-[node."glibc-2.28-189.5.el8_6.x86_64"]
+[rpm."glibc-2.28-189.5.el8_6.x86_64"]
 filter_files = [ "/sbin/ldconfig" ]
 
-[node."cri-o-1.25.3-5.rhaos4.12.git44a2cb2.el8.x86_64"]
+[rpm."cri-o-1.25.3-5.rhaos4.12.git44a2cb2.el8.x86_64"]
 filter_files = [
   "/usr/bin/crio",
   "/usr/bin/crio-status",
   "/usr/bin/pinns",
 ]
 
-[node."podman-4.2.0-6.1.rhaos4.12.el8.x86_64"]
+[rpm."podman-4.2.0-6.1.rhaos4.12.el8.x86_64"]
 filter_files = [
   "/usr/bin/podman",
   "/usr/libexec/podman/rootlessport",
 ]
 
-[node."ignition-2.14.0-6.rhaos4.12.el8.x86_64"]
+[rpm."ignition-2.14.0-6.rhaos4.12.el8.x86_64"]
 filter_files = [
   "/usr/lib/dracut/modules.d/30ignition/ignition"
 ]
 
-[node."skopeo-1.9.4-3.1.rhaos4.12.el8.x86_64"]
+[rpm."skopeo-1.9.4-3.1.rhaos4.12.el8.x86_64"]
 filter_files = [
   "/usr/bin/skopeo"
 ]
 
-[node."podman-catatonit-4.2.0-6.1.rhaos4.12.el8.x86_64"]
+[rpm."podman-catatonit-4.2.0-6.1.rhaos4.12.el8.x86_64"]
 filter_files = [
   "/usr/libexec/catatonit/catatonit"
 ]
 
-[node."containernetworking-plugins-1.0.1-7.rhaos4.12.el8.x86_64"]
+[rpm."containernetworking-plugins-1.0.1-7.rhaos4.12.el8.x86_64"]
 filter_files = [
 "/usr/libexec/cni/bandwidth",
 "/usr/libexec/cni/bridge",

--- a/dist/releases/4.12/config.toml
+++ b/dist/releases/4.12/config.toml
@@ -28,44 +28,44 @@ filter_images = [ ]
 
 # Node Ignores
 # these node exceptions via rpm have been manually validated
-[rpm."runc-1.1.6-4.rhaos4.12.el8.x86_64"]
+[rpm.runc]
 filter_files = [ "/usr/bin/runc" ]
 
-[rpm."cri-tools-1.25.0-2.el8.x86_64"]
+[rpm.cri-tools]
 filter_files = [ "/usr/bin/crictl" ]
 
-[rpm."glibc-2.28-189.5.el8_6.x86_64"]
+[rpm.glibc]
 filter_files = [ "/sbin/ldconfig" ]
 
-[rpm."cri-o-1.25.3-5.rhaos4.12.git44a2cb2.el8.x86_64"]
+[rpm.cri-o]
 filter_files = [
   "/usr/bin/crio",
   "/usr/bin/crio-status",
   "/usr/bin/pinns",
 ]
 
-[rpm."podman-4.2.0-6.1.rhaos4.12.el8.x86_64"]
+[rpm.podman]
 filter_files = [
   "/usr/bin/podman",
   "/usr/libexec/podman/rootlessport",
 ]
 
-[rpm."ignition-2.14.0-6.rhaos4.12.el8.x86_64"]
+[rpm.ignition]
 filter_files = [
   "/usr/lib/dracut/modules.d/30ignition/ignition"
 ]
 
-[rpm."skopeo-1.9.4-3.1.rhaos4.12.el8.x86_64"]
+[rpm.skopeo]
 filter_files = [
   "/usr/bin/skopeo"
 ]
 
-[rpm."podman-catatonit-4.2.0-6.1.rhaos4.12.el8.x86_64"]
+[rpm.podman-catatonit]
 filter_files = [
   "/usr/libexec/catatonit/catatonit"
 ]
 
-[rpm."containernetworking-plugins-1.0.1-7.rhaos4.12.el8.x86_64"]
+[rpm.containernetworking-plugins]
 filter_files = [
 "/usr/libexec/cni/bandwidth",
 "/usr/libexec/cni/bridge",

--- a/dist/releases/4.13/config.toml
+++ b/dist/releases/4.13/config.toml
@@ -58,44 +58,44 @@ filter_images = [ ]
 
 # Node Ignores
 # these node exceptions via rpm have been manually validated
-[rpm."runc-1.1.6-4.rhaos4.12.el8.x86_64"]
+[rpm.runc]
 filter_files = [ "/usr/bin/runc" ]
 
-[rpm."cri-tools-1.25.0-2.el8.x86_64"]
+[rpm.cri-tools]
 filter_files = [ "/usr/bin/crictl" ]
 
-[rpm."glibc-2.28-189.5.el8_6.x86_64"]
+[rpm.glibc]
 filter_files = [ "/sbin/ldconfig" ]
 
-[rpm."cri-o-1.25.3-5.rhaos4.12.git44a2cb2.el8.x86_64"]
+[rpm.cri-o]
 filter_files = [
   "/usr/bin/crio",
   "/usr/bin/crio-status",
   "/usr/bin/pinns",
 ]
 
-[rpm."podman-4.2.0-6.1.rhaos4.12.el8.x86_64"]
+[rpm.podman]
 filter_files = [
   "/usr/bin/podman",
   "/usr/libexec/podman/rootlessport",
 ]
 
-[rpm."ignition-2.14.0-6.rhaos4.12.el8.x86_64"]
+[rpm.ignition]
 filter_files = [
   "/usr/lib/dracut/modules.d/30ignition/ignition"
 ]
 
-[rpm."skopeo-1.9.4-3.1.rhaos4.12.el8.x86_64"]
+[rpm.skopeo]
 filter_files = [
   "/usr/bin/skopeo"
 ]
 
-[rpm."podman-catatonit-4.2.0-6.1.rhaos4.12.el8.x86_64"]
+[rpm.podman-catatonit]
 filter_files = [
   "/usr/libexec/catatonit/catatonit"
 ]
 
-[rpm."containernetworking-plugins-1.0.1-7.rhaos4.12.el8.x86_64"]
+[rpm.containernetworking-plugins]
 filter_files = [
 "/usr/libexec/cni/bandwidth",
 "/usr/libexec/cni/bridge",

--- a/dist/releases/4.13/config.toml
+++ b/dist/releases/4.13/config.toml
@@ -58,44 +58,44 @@ filter_images = [ ]
 
 # Node Ignores
 # these node exceptions via rpm have been manually validated
-[node."runc-1.1.6-4.rhaos4.12.el8.x86_64"]
+[rpm."runc-1.1.6-4.rhaos4.12.el8.x86_64"]
 filter_files = [ "/usr/bin/runc" ]
 
-[node."cri-tools-1.25.0-2.el8.x86_64"]
+[rpm."cri-tools-1.25.0-2.el8.x86_64"]
 filter_files = [ "/usr/bin/crictl" ]
 
-[node."glibc-2.28-189.5.el8_6.x86_64"]
+[rpm."glibc-2.28-189.5.el8_6.x86_64"]
 filter_files = [ "/sbin/ldconfig" ]
 
-[node."cri-o-1.25.3-5.rhaos4.12.git44a2cb2.el8.x86_64"]
+[rpm."cri-o-1.25.3-5.rhaos4.12.git44a2cb2.el8.x86_64"]
 filter_files = [
   "/usr/bin/crio",
   "/usr/bin/crio-status",
   "/usr/bin/pinns",
 ]
 
-[node."podman-4.2.0-6.1.rhaos4.12.el8.x86_64"]
+[rpm."podman-4.2.0-6.1.rhaos4.12.el8.x86_64"]
 filter_files = [
   "/usr/bin/podman",
   "/usr/libexec/podman/rootlessport",
 ]
 
-[node."ignition-2.14.0-6.rhaos4.12.el8.x86_64"]
+[rpm."ignition-2.14.0-6.rhaos4.12.el8.x86_64"]
 filter_files = [
   "/usr/lib/dracut/modules.d/30ignition/ignition"
 ]
 
-[node."skopeo-1.9.4-3.1.rhaos4.12.el8.x86_64"]
+[rpm."skopeo-1.9.4-3.1.rhaos4.12.el8.x86_64"]
 filter_files = [
   "/usr/bin/skopeo"
 ]
 
-[node."podman-catatonit-4.2.0-6.1.rhaos4.12.el8.x86_64"]
+[rpm."podman-catatonit-4.2.0-6.1.rhaos4.12.el8.x86_64"]
 filter_files = [
   "/usr/libexec/catatonit/catatonit"
 ]
 
-[node."containernetworking-plugins-1.0.1-7.rhaos4.12.el8.x86_64"]
+[rpm."containernetworking-plugins-1.0.1-7.rhaos4.12.el8.x86_64"]
 filter_files = [
 "/usr/libexec/cni/bandwidth",
 "/usr/libexec/cni/bridge",

--- a/dist/releases/4.9/config.toml
+++ b/dist/releases/4.9/config.toml
@@ -28,18 +28,18 @@ filter_files = [
 filter_images = [ ]
 
 # these node exceptions via rpm have been manually validated
-[rpm."cri-o-1.22.5-20.rhaos4.9.gitdf6ec18.el8.x86_64"]
+[rpm.cri-o]
 filter_files = [
   "/usr/bin/pinns",
 ]
 
-[rpm."glibc-2.28-151.el8.x86_64"]
+[rpm.glibc]
 filter_files = [ "/sbin/ldconfig" ]
 
-[rpm."cri-o-1.23.5-16.rhaos4.10.gitbb2cc9a.el8.x86_64"]
+[rpm.cri-o]
 filter_files = [ "/usr/bin/pinns" ]
 
-[rpm."podman-catatonit-3.2.3-0.12.module+el8.4.0+14908+81312c48.x86_64"]
+[rpm.podman-catatonit]
 filter_files = [ "/usr/libexec/catatonit/catatonit" ]
 
 # Payload Components

--- a/dist/releases/4.9/config.toml
+++ b/dist/releases/4.9/config.toml
@@ -28,18 +28,18 @@ filter_files = [
 filter_images = [ ]
 
 # these node exceptions via rpm have been manually validated
-[node."cri-o-1.22.5-20.rhaos4.9.gitdf6ec18.el8.x86_64"]
+[rpm."cri-o-1.22.5-20.rhaos4.9.gitdf6ec18.el8.x86_64"]
 filter_files = [
   "/usr/bin/pinns",
 ]
 
-[node."glibc-2.28-151.el8.x86_64"]
+[rpm."glibc-2.28-151.el8.x86_64"]
 filter_files = [ "/sbin/ldconfig" ]
 
-[node."cri-o-1.23.5-16.rhaos4.10.gitbb2cc9a.el8.x86_64"]
+[rpm."cri-o-1.23.5-16.rhaos4.10.gitbb2cc9a.el8.x86_64"]
 filter_files = [ "/usr/bin/pinns" ]
 
-[node."podman-catatonit-3.2.3-0.12.module+el8.4.0+14908+81312c48.x86_64"]
+[rpm."podman-catatonit-3.2.3-0.12.module+el8.4.0+14908+81312c48.x86_64"]
 filter_files = [ "/usr/libexec/catatonit/catatonit" ]
 
 # Payload Components

--- a/internal/rpm/rpm.go
+++ b/internal/rpm/rpm.go
@@ -1,0 +1,49 @@
+package rpm
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+
+	"k8s.io/klog/v2"
+)
+
+func GetFilesFromRPM(ctx context.Context, root, rpm string) ([]string, error) {
+	klog.Infof("rpm -ql %v", rpm)
+	files := []string{}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, "rpm", "-ql", "--root", root, rpm)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return files, fmt.Errorf("rpm -ql error: %w (stderr=%v)", err, stderr.String())
+	}
+
+	scanner := bufio.NewScanner(&stdout)
+	for scanner.Scan() {
+		files = append(files, scanner.Text())
+	}
+	return files, nil
+}
+
+func GetAllRPMs(ctx context.Context, root string) ([]string, error) {
+	klog.Info("rpm -qa")
+	rpms := []string{}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, "rpm", "-qa", "--root", root)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return rpms, fmt.Errorf("rpm -qa error: %w (stderr=%v)", err, stderr.String())
+	}
+
+	scanner := bufio.NewScanner(&stdout)
+	for scanner.Scan() {
+		rpms = append(rpms, scanner.Text())
+	}
+	return rpms, nil
+}

--- a/internal/scan/node_scan.go
+++ b/internal/scan/node_scan.go
@@ -33,15 +33,15 @@ func RunNodeScan(ctx context.Context, cfg *types.Config) []*types.ScanResults {
 	root := cfg.NodeScan
 	rpms, _ := rpm.GetAllRPMs(ctx, root)
 	for _, pkg := range rpms {
-		tag := NewTag(pkg)
-		files, err := rpm.GetFilesFromRPM(ctx, root, pkg)
+		tag := NewTag(pkg.Name)
+		files, err := rpm.GetFilesFromRPM(ctx, root, pkg.NVRA)
 		if err != nil {
 			res := types.NewScanResult().SetTag(tag).SetError(err)
 			results.Append(res)
 			continue
 		}
 		for _, innerPath := range files {
-			if cfg.IgnoreFile(innerPath) || cfg.IgnoreDirPrefix(innerPath) || cfg.IgnoreFileByRpm(innerPath, pkg) {
+			if cfg.IgnoreFile(innerPath) || cfg.IgnoreDirPrefix(innerPath) || cfg.IgnoreFileByRpm(innerPath, pkg.Name) {
 				continue
 			}
 			path := filepath.Join(cfg.NodeScan, innerPath)

--- a/internal/scan/node_scan.go
+++ b/internal/scan/node_scan.go
@@ -33,7 +33,6 @@ func RunNodeScan(ctx context.Context, cfg *types.Config) []*types.ScanResults {
 	component := &types.OpenshiftComponent{
 		Component: "node",
 	}
-	nodeVersion := "default"
 	rpms, _ := getAllRPMs(ctx, cfg)
 	for _, rpm := range rpms {
 		tag := NewTag(rpm)
@@ -44,7 +43,7 @@ func RunNodeScan(ctx context.Context, cfg *types.Config) []*types.ScanResults {
 			continue
 		}
 		for _, innerPath := range files {
-			if cfg.IgnoreFile(innerPath) || cfg.IgnoreDirPrefix(innerPath) || cfg.IgnoreFileByNode(innerPath, nodeVersion) || cfg.IgnoreFileByRpm(innerPath, rpm) {
+			if cfg.IgnoreFile(innerPath) || cfg.IgnoreDirPrefix(innerPath) || cfg.IgnoreFileByRpm(innerPath, rpm) {
 				continue
 			}
 			path := filepath.Join(cfg.NodeScan, innerPath)

--- a/internal/scan/node_scan.go
+++ b/internal/scan/node_scan.go
@@ -1,18 +1,15 @@
 package scan
 
 import (
-	"bufio"
-	"bytes"
 	"context"
-	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 
 	v1 "github.com/openshift/api/image/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
+	"github.com/openshift/check-payload/internal/rpm"
 	"github.com/openshift/check-payload/internal/types"
 	"github.com/openshift/check-payload/internal/validations"
 )
@@ -34,17 +31,17 @@ func RunNodeScan(ctx context.Context, cfg *types.Config) []*types.ScanResults {
 		Component: "node",
 	}
 	root := cfg.NodeScan
-	rpms, _ := getAllRPMs(ctx, root)
-	for _, rpm := range rpms {
-		tag := NewTag(rpm)
-		files, err := getFilesFromRPM(ctx, root, rpm)
+	rpms, _ := rpm.GetAllRPMs(ctx, root)
+	for _, pkg := range rpms {
+		tag := NewTag(pkg)
+		files, err := rpm.GetFilesFromRPM(ctx, root, pkg)
 		if err != nil {
 			res := types.NewScanResult().SetTag(tag).SetError(err)
 			results.Append(res)
 			continue
 		}
 		for _, innerPath := range files {
-			if cfg.IgnoreFile(innerPath) || cfg.IgnoreDirPrefix(innerPath) || cfg.IgnoreFileByRpm(innerPath, rpm) {
+			if cfg.IgnoreFile(innerPath) || cfg.IgnoreDirPrefix(innerPath) || cfg.IgnoreFileByRpm(innerPath, pkg) {
 				continue
 			}
 			path := filepath.Join(cfg.NodeScan, innerPath)
@@ -74,42 +71,4 @@ func RunNodeScan(ctx context.Context, cfg *types.Config) []*types.ScanResults {
 		}
 	}
 	return runs
-}
-
-func getFilesFromRPM(ctx context.Context, root, rpm string) ([]string, error) {
-	klog.Infof("rpm -ql %v", rpm)
-	files := []string{}
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	cmd := exec.CommandContext(ctx, "rpm", "-ql", "--root", root, rpm)
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return files, fmt.Errorf("rpm -ql error: %w (stderr=%v)", err, stderr.String())
-	}
-
-	scanner := bufio.NewScanner(&stdout)
-	for scanner.Scan() {
-		files = append(files, scanner.Text())
-	}
-	return files, nil
-}
-
-func getAllRPMs(ctx context.Context, root string) ([]string, error) {
-	klog.Info("rpm -qa")
-	rpms := []string{}
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	cmd := exec.CommandContext(ctx, "rpm", "-qa", "--root", root)
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return rpms, fmt.Errorf("rpm -qa error: %w (stderr=%v)", err, stderr.String())
-	}
-
-	scanner := bufio.NewScanner(&stdout)
-	for scanner.Scan() {
-		rpms = append(rpms, scanner.Text())
-	}
-	return rpms, nil
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -32,7 +32,7 @@ type Config struct {
 
 	PayloadIgnores map[string]IgnoreLists `toml:"payload"`
 	TagIgnores     map[string]IgnoreLists `toml:"tag"`
-	NodeIgnores    map[string]IgnoreLists `toml:"node"`
+	RPMIgnores     map[string]IgnoreLists `toml:"rpm"`
 }
 
 type IgnoreLists struct {

--- a/internal/types/types_config.go
+++ b/internal/types/types_config.go
@@ -74,10 +74,6 @@ func (c *Config) IgnoreFileWithTag(path string, tag *imagev1.TagReference) bool 
 	return c.isFileIgnoredByTag(path, tag)
 }
 
-func (c *Config) IgnoreFileByNode(path string, nodeVersion string) bool {
-	return c.isFileIgnoredByNode(path, nodeVersion)
-}
-
 func (c *Config) IgnoreFileByRpm(path string, rpm string) bool {
 	return c.isFileIgnoredByNode(path, rpm)
 }

--- a/internal/types/types_config.go
+++ b/internal/types/types_config.go
@@ -51,8 +51,8 @@ func (c *Config) isFileIgnoredByTag(path string, tag *imagev1.TagReference) bool
 	return false
 }
 
-func (c *Config) isFileIgnoredByNode(path string, tag string) bool {
-	if op, ok := c.NodeIgnores[tag]; ok {
+func (c *Config) isFileIgnoredByRPM(path string, rpm string) bool {
+	if op, ok := c.RPMIgnores[rpm]; ok {
 		return isMatch(path, op.FilterFiles)
 	}
 	return false
@@ -75,7 +75,7 @@ func (c *Config) IgnoreFileWithTag(path string, tag *imagev1.TagReference) bool 
 }
 
 func (c *Config) IgnoreFileByRpm(path string, rpm string) bool {
-	return c.isFileIgnoredByNode(path, rpm)
+	return c.isFileIgnoredByRPM(path, rpm)
 }
 
 func (c *Config) IgnoreDirWithComponent(path string, component *OpenshiftComponent) bool {


### PR DESCRIPTION
This is done in preparation to support per-rpm exclusions in payload scan.
Please see individual commit messages for details.

The only notable changes are:
 - `node.` is now `rpm.` in configs;
 - only the rpm name is used in configs.