### PR TITLE
chore: CRW-4582 exclude /usr/libexec/catatonit/catatonit in payload.devspaces-udi-rhel8-container as it's already excluded in root config.toml

### DIFF
--- a/dist/releases/4.10/config.toml
+++ b/dist/releases/4.10/config.toml
@@ -55,6 +55,8 @@ filter_files = [
 
 [payload.devspaces-udi-rhel8-container]
 filter_files = [
+  ### excluded in main config.toml so re-excluding it here
+  "/usr/libexec/catatonit/catatonit",
   ### include golang compiler intentionally; exception needed until https://issues.redhat.com/browse/GT-130 is resolved
   "/usr/lib/golang/pkg/tool/linux_amd64/compile",
   "/usr/lib/golang/pkg/tool/linux_ppc64le/compile",

--- a/dist/releases/4.11/config.toml
+++ b/dist/releases/4.11/config.toml
@@ -155,6 +155,8 @@ filter_files = [
 
 [payload.devspaces-udi-rhel8-container]
 filter_files = [
+  ### excluded in main config.toml so re-excluding it here
+  "/usr/libexec/catatonit/catatonit",
   ### include golang compiler intentionally; exception needed until https://issues.redhat.com/browse/GT-130 is resolved
   "/usr/lib/golang/pkg/tool/linux_amd64/compile",
   "/usr/lib/golang/pkg/tool/linux_ppc64le/compile",

--- a/dist/releases/4.12/config.toml
+++ b/dist/releases/4.12/config.toml
@@ -186,6 +186,8 @@ filter_files = [
 
 [payload.devspaces-udi-rhel8-container]
 filter_files = [
+  ### excluded in main config.toml so re-excluding it here
+  "/usr/libexec/catatonit/catatonit",
   ### include golang compiler intentionally; exception needed until https://issues.redhat.com/browse/GT-130 is resolved
   "/usr/lib/golang/pkg/tool/linux_amd64/compile",
   "/usr/lib/golang/pkg/tool/linux_ppc64le/compile",

--- a/dist/releases/4.13/config.toml
+++ b/dist/releases/4.13/config.toml
@@ -215,6 +215,8 @@ filter_files = [
 
 [payload.devspaces-udi-rhel8-container]
 filter_files = [
+  ### excluded in main config.toml so re-excluding it here
+  "/usr/libexec/catatonit/catatonit",
   ### include golang compiler intentionally; exception needed until https://issues.redhat.com/browse/GT-130 is resolved
   "/usr/lib/golang/pkg/tool/linux_amd64/compile",
   "/usr/lib/golang/pkg/tool/linux_ppc64le/compile",


### PR DESCRIPTION
chore: [CRW-4582](https://issues.redhat.com//browse/CRW-4582) exclude /usr/libexec/catatonit/catatonit in payload.devspaces-udi-rhel8-container as it's already excluded in root config.toml

Signed-off-by: Nick Boldt <nboldt@redhat.com>