### PR TITLE
Rpm to scan

### DIFF
--- a/internal/rpm/rpm.go
+++ b/internal/rpm/rpm.go
@@ -5,7 +5,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"k8s.io/klog/v2"
@@ -57,4 +59,63 @@ func GetAllRPMs(ctx context.Context, root string) ([]Info, error) {
 		rpms = append(rpms, Info{Name: f[0], NVRA: f[1]})
 	}
 	return rpms, nil
+}
+
+// NameFromFile tells which rpm the given file belongs to, under a given root.
+func NameFromFile(ctx context.Context, root, path string) (string, error) {
+	// We can either:
+	//  1: Execute host's rpm binary;
+	//  2: Execute in-root rpm binary using chroot;
+	//  3: Use something like https://github.com/knqyf263/go-rpmdb
+	//
+	// Every approach has its pros and cons.
+	//  1: We have to find where rpmdb is located, as in-root configuration
+	//     may differ from the host one, and we assume host rpm understands
+	//     in-root rpmdb format.
+	//  2: We have to trust rpm binary, and it has to be of the same arch.
+	//  3: We have to trust the third-party package, and it might be slow
+	//     or not have all the required functionality.
+	//
+	// Let's settle on 1 for now.
+
+	dbpath, err := rpmDBPath(root)
+	if err != nil {
+		return "", err
+	}
+	cmd := exec.CommandContext(ctx, "rpm", "-qf", "--dbpath", dbpath, "--root", root, "--queryformat=%{NAME}", path)
+	cmd.Env = append(cmd.Environ(), "LANG=C") // Do not localize error messages.
+	var outbuf, errbuf bytes.Buffer
+	cmd.Stdout = &outbuf
+	cmd.Stderr = &errbuf
+
+	if err := cmd.Run(); err != nil {
+		errB := errbuf.Bytes()
+		// If the file does not belong to any package, do not return an error.
+		if bytes.Contains(errB, []byte("is not owned by any package")) ||
+			// If the file is not owned by any package, and a file
+			// with the same path does not exist *on the host*, the
+			// error message is ENOENT. This seems to be rpm bug, see
+			// https://github.com/rpm-software-management/rpm/issues/2576.
+			bytes.Contains(errB, []byte("No such file or directory")) {
+			return "", nil
+		}
+		return "", fmt.Errorf("rpm -qf error: %w (stderr=%s)", err, strings.TrimSpace(errbuf.String()))
+	}
+	return strings.TrimSpace(outbuf.String()), nil
+}
+
+// rpmDBPath tries to guess the location of the rpmdb inside a given root.
+// It is needed because different systems use different paths (see
+// https://fedoraproject.org/wiki/Changes/RelocateRPMToUsr,
+// https://coreos.github.io/rpm-ostree/#filesystem-layout).
+func rpmDBPath(root string) (string, error) {
+	for _, path := range []string{"/var/lib/rpm", "/usr/share/rpm", "/usr/lib/sysimage/rpm"} {
+		// Do not trust symlinks as they might be absolute
+		// (the alternative is to use github.com/cyphar/filepath-securejoin).
+		st, err := os.Lstat(filepath.Join(root, path))
+		if err == nil && st.IsDir() {
+			return path, nil
+		}
+	}
+	return "", fmt.Errorf("can't find rpmdb under %q", root)
 }

--- a/internal/scan/printer.go
+++ b/internal/scan/printer.go
@@ -14,10 +14,11 @@ import (
 var (
 	colTitleOperatorName = "Operator Name"
 	colTitleTagName      = "Tag Name"
+	colTitleRPMName      = "RPM Name"
 	colTitleExeName      = "Executable Name"
 	colTitlePassedFailed = "Status"
 	colTitleImage        = "Image"
-	failureRowHeader     = table.Row{colTitleOperatorName, colTitleTagName, colTitleExeName, colTitlePassedFailed, colTitleImage}
+	failureRowHeader     = table.Row{colTitleOperatorName, colTitleTagName, colTitleRPMName, colTitleExeName, colTitlePassedFailed, colTitleImage}
 	successRowHeader     = table.Row{colTitleOperatorName, colTitleTagName, colTitleExeName, colTitleImage}
 )
 
@@ -199,9 +200,9 @@ func renderReport(results []*types.ScanResults) (failures table.Writer, warnings
 		for _, res := range result.Items {
 			component := getComponent(res)
 			if res.IsLevel(types.Error) {
-				failureTableRows = append(failureTableRows, table.Row{component, res.Tag.Name, res.Path, res.Error.GetError(), res.Tag.From.Name})
+				failureTableRows = append(failureTableRows, table.Row{component, res.Tag.Name, res.RPM, res.Path, res.Error.GetError(), res.Tag.From.Name})
 			} else if res.IsLevel(types.Warning) {
-				warningTableRows = append(warningTableRows, table.Row{component, res.Tag.Name, res.Path, res.Error.GetError(), res.Tag.From.Name})
+				warningTableRows = append(warningTableRows, table.Row{component, res.Tag.Name, res.RPM, res.Path, res.Error.GetError(), res.Tag.From.Name})
 			} else {
 				successTableRows = append(successTableRows, table.Row{component, res.Tag.Name, res.Path, res.Tag.From.Name})
 			}

--- a/internal/scan/printer.go
+++ b/internal/scan/printer.go
@@ -124,9 +124,9 @@ func generateNodeScanReport(results []*types.ScanResults, cfg *types.Config) (st
 	for _, result := range results {
 		for _, res := range result.Items {
 			if res.IsLevel(types.Error) {
-				failureTableRows = append(failureTableRows, table.Row{res.Path, res.Error.GetError(), res.Tag.From.Name})
+				failureTableRows = append(failureTableRows, table.Row{res.Path, res.Error.GetError(), res.RPM})
 			} else if res.IsLevel(types.Warning) {
-				warningTableRows = append(warningTableRows, table.Row{res.Path, res.Error.GetError(), res.Tag.From.Name})
+				warningTableRows = append(warningTableRows, table.Row{res.Path, res.Error.GetError(), res.RPM})
 			} else {
 				successTableRows = append(successTableRows, table.Row{res.Path})
 			}

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -264,6 +264,10 @@ func validateTag(ctx context.Context, tag *v1.TagReference, cfg *types.Config) *
 			// Do not add skipped binaries to results.
 			return nil
 		}
+		// Check rpm.* excludes. Performed post-check because the rpm name was not known before.
+		if !res.IsSuccess() && res.RPM != "" && cfg.IgnoreFileByRpm(innerPath, res.RPM) {
+			return nil
+		}
 		if res.IsSuccess() {
 			klog.V(1).InfoS("scanning success", "image", image, "path", innerPath, "status", "success")
 		} else if res.IsLevel(types.Warning) {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -48,6 +48,7 @@ type ArtifactPod struct {
 type ScanResult struct {
 	Component *OpenshiftComponent
 	Tag       *v1.TagReference
+	RPM       string
 	Path      string
 	Skip      bool
 	Error     *ValidationError

--- a/internal/types/types_scan_result.go
+++ b/internal/types/types_scan_result.go
@@ -62,3 +62,8 @@ func (r *ScanResult) SetTag(tag *v1.TagReference) *ScanResult {
 	r.Tag = tag
 	return r
 }
+
+func (r *ScanResult) SetRPM(rpm string) *ScanResult {
+	r.RPM = rpm
+	return r
+}


### PR DESCRIPTION
This adds rpm name support to payload scan, so we can see which rpm the failed file belongs to, as well as use per-rpm exclusions (previously only available to node scans) for payload scans.

TODO: convert configs to mostly contain rpm-based exclusions (NOT in this PR).