### PR TITLE
hotfix: fix 4.9 config

### DIFF
--- a/dist/releases/4.9/config.toml
+++ b/dist/releases/4.9/config.toml
@@ -28,11 +28,6 @@ filter_files = [
 filter_images = [ ]
 
 # these node exceptions via rpm have been manually validated
-[rpm.cri-o]
-filter_files = [
-  "/usr/bin/pinns",
-]
-
 [rpm.glibc]
 filter_files = [ "/sbin/ldconfig" ]
 


### PR DESCRIPTION
Commit 33b5277ec32d resulted in two rpm.cri-o sections.

Remove the duplicate (which results in a panic -- we need to add a CI job to prevent this).