### PR TITLE
perf: skip all files with no x bit set

### DIFF
--- a/internal/scan/node_scan.go
+++ b/internal/scan/node_scan.go
@@ -39,8 +39,9 @@ func RunNodeScan(ctx context.Context, cfg *types.Config) []*types.ScanResults {
 				// some files are stripped from an rhcos image
 				continue
 			}
-			if m := fileInfo.Mode(); !m.IsRegular() {
-				// Skip all non-regular files (directories, symlinks).
+			if m := fileInfo.Mode(); !m.IsRegular() || m.Perm()&0o111 == 0 {
+				// Skip all non-regular files (directories, symlinks),
+				// and regular files that has no x bit set.
 				continue
 			}
 			klog.V(1).InfoS("scanning path", "path", path)

--- a/internal/scan/node_scan.go
+++ b/internal/scan/node_scan.go
@@ -39,10 +39,8 @@ func RunNodeScan(ctx context.Context, cfg *types.Config) []*types.ScanResults {
 				// some files are stripped from an rhcos image
 				continue
 			}
-			if fileInfo.IsDir() {
-				continue
-			}
-			if fileInfo.Mode()&os.ModeSymlink != 0 {
+			if m := fileInfo.Mode(); !m.IsRegular() {
+				// Skip all non-regular files (directories, symlinks).
 				continue
 			}
 			klog.V(1).InfoS("scanning path", "path", path)


### PR DESCRIPTION
Such files are most probably not binaries, or they are binaries that
can't be executed (until `x` bit is set, that is).
    
This helps to skip calling `isElfExe` for most libraries.

Shows a noticeable improvement on my machine.
    
