### PR TITLE
Node scan hotfixes

### DIFF
--- a/internal/rpm/rpm.go
+++ b/internal/rpm/rpm.go
@@ -20,16 +20,19 @@ type Info struct {
 
 func GetFilesFromRPM(ctx context.Context, root, rpm string) ([]string, error) {
 	klog.Infof("rpm -ql %v", rpm)
-	files := []string{}
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	cmd := exec.CommandContext(ctx, "rpm", "-ql", "--root", root, rpm)
+	dbpath, err := rpmDBPath(root)
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.CommandContext(ctx, "rpm", "-ql", "--dbpath", dbpath, "--root", root, rpm)
+	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return files, fmt.Errorf("rpm -ql error: %w (stderr=%v)", err, stderr.String())
+		return nil, fmt.Errorf("rpm -ql error: %w (stderr=%v)", err, stderr.String())
 	}
 
+	files := []string{}
 	scanner := bufio.NewScanner(&stdout)
 	for scanner.Scan() {
 		files = append(files, scanner.Text())
@@ -39,9 +42,12 @@ func GetFilesFromRPM(ctx context.Context, root, rpm string) ([]string, error) {
 
 func GetAllRPMs(ctx context.Context, root string) ([]Info, error) {
 	klog.Info("rpm -qa")
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	cmd := exec.CommandContext(ctx, "rpm", "-qa", "--root", root, "--qf", "%{NAME} %{NVRA}\n")
+	dbpath, err := rpmDBPath(root)
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.CommandContext(ctx, "rpm", "-qa", "--dbpath", dbpath, "--root", root, "--qf", "%{NAME} %{NVRA}\n")
+	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {

--- a/internal/rpm/rpm.go
+++ b/internal/rpm/rpm.go
@@ -64,6 +64,12 @@ func GetAllRPMs(ctx context.Context, root string) ([]Info, error) {
 		}
 		rpms = append(rpms, Info{Name: f[0], NVRA: f[1]})
 	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error reading rpm -qa: %w", err)
+	}
+	if len(rpms) == 0 {
+		return nil, fmt.Errorf("no rpms found under %q", root)
+	}
 	return rpms, nil
 }
 

--- a/internal/rpm/rpm.go
+++ b/internal/rpm/rpm.go
@@ -41,7 +41,7 @@ func GetAllRPMs(ctx context.Context, root string) ([]Info, error) {
 	klog.Info("rpm -qa")
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	cmd := exec.CommandContext(ctx, "rpm", "-qa", "--root", root, "--qf", "%{NAME} %{NVRA}")
+	cmd := exec.CommandContext(ctx, "rpm", "-qa", "--root", root, "--qf", "%{NAME} %{NVRA}\n")
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {

--- a/internal/scan/node_scan.go
+++ b/internal/scan/node_scan.go
@@ -21,7 +21,11 @@ func RunNodeScan(ctx context.Context, cfg *types.Config) []*types.ScanResults {
 		Component: "node",
 	}
 	root := cfg.NodeScan
-	rpms, _ := rpm.GetAllRPMs(ctx, root)
+	rpms, err := rpm.GetAllRPMs(ctx, root)
+	if err != nil {
+		results.Append(types.NewScanResult().SetError(err))
+		return runs
+	}
 	for _, pkg := range rpms {
 		files, err := rpm.GetFilesFromRPM(ctx, root, pkg.NVRA)
 		if err != nil {


### PR DESCRIPTION
This fixes three issues with node scan, two of which prevented node scans from working.

The first one was introduced by #75 and broke all node scans.
The second one was there from the beginning and broke some node scans.
The last issue was not reporting errors from `rpm -qa`.

See individual commits for more details.

Tested to fix the issue of not being able to use node scan.