### PR TITLE
Use debug/elf to check for dynamic binaries

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,14 +28,12 @@ const (
 var embeddedConfig string
 
 var applicationDeps = []string{
-	"file",
 	"nm",
 	"oc",
 	"podman",
 }
 
 var applicationDepsNodeScan = []string{
-	"file",
 	"nm",
 	"rpm",
 }


### PR DESCRIPTION
~~_(based on and currently includes #87; draft until that one is merged; if you want to review, see the last commit only)_~~

Instead of running `file`, use debug/elf (which we already use anyway)
to check for static binaries, which is much faster.