### PR TITLE
test: check that embedded configs are sane

### DIFF
--- a/dist/releases/config_test.go
+++ b/dist/releases/config_test.go
@@ -1,0 +1,29 @@
+package releases_test
+
+import (
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/openshift/check-payload/dist/releases"
+	"github.com/openshift/check-payload/internal/types"
+)
+
+const mainConfig = "../../config.toml"
+
+func testConfigIsSane(t *testing.T, file string) {
+	config := &types.ConfigFile{}
+	res, err := toml.DecodeFile(file, &config)
+	if err != nil {
+		t.Errorf("invalid config file %q: %v", file, err)
+	}
+	if un := res.Undecoded(); len(un) != 0 {
+		t.Errorf("unknown keys in config %q: %+v", file, un)
+	}
+}
+
+func TestConfigsAreSane(t *testing.T) {
+	testConfigIsSane(t, mainConfig)
+	for _, dir := range releases.GetVersions() {
+		testConfigIsSane(t, dir+"/config.toml")
+	}
+}

--- a/dist/releases/embeds.go
+++ b/dist/releases/embeds.go
@@ -9,20 +9,27 @@ import (
 //go:embed */*
 var configs embed.FS
 
-func GetConfigFor(version string) ([]byte, error) {
-	bytes, err := configs.ReadFile(filepath.Join(version, "config.toml"))
-	if err == nil {
-		return bytes, nil
-	}
-	// Add a list of valid versions to the error message.
+// GetVersions returns the list of versions for those embedded configs
+// are available.
+func GetVersions() []string {
 	dirs, err := configs.ReadDir(".")
 	if err != nil { // Should not happen.
-		return nil, fmt.Errorf("internal error: %w", err)
+		return nil
 	}
 	names := make([]string, len(dirs))
 	for i, d := range dirs {
 		names[i] = d.Name()
 	}
 
-	return nil, fmt.Errorf("embedded config for version %s is not available; use one of %+v", version, names)
+	return names
+}
+
+// GetConfigFor returns the configuration for a given version, if found.
+func GetConfigFor(version string) ([]byte, error) {
+	bytes, err := configs.ReadFile(filepath.Join(version, "config.toml"))
+	if err == nil {
+		return bytes, nil
+	}
+
+	return nil, fmt.Errorf("embedded config for version %s is not available; use one of %+v", version, GetVersions())
 }


### PR DESCRIPTION
The test checks that
 - configs can be parsed
 - there are no unknown/unparsed parts
 
 This ensures there are no runtime errors due to bad embedded configs.