### PR TITLE
feat: add dirs to per-error exclusion lists

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -35,26 +35,7 @@ files = [ "/usr/libexec/catatonit/catatonit" ]
 
 [[rpm.containernetworking-plugins.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/libexec/cni/bandwidth",
-  "/usr/libexec/cni/bridge",
-  "/usr/libexec/cni/dhcp",
-  "/usr/libexec/cni/dummy",
-  "/usr/libexec/cni/firewall",
-  "/usr/libexec/cni/host-device",
-  "/usr/libexec/cni/host-local",
-  "/usr/libexec/cni/ipvlan",
-  "/usr/libexec/cni/loopback",
-  "/usr/libexec/cni/macvlan",
-  "/usr/libexec/cni/portmap",
-  "/usr/libexec/cni/ptp",
-  "/usr/libexec/cni/sample",
-  "/usr/libexec/cni/sbr",
-  "/usr/libexec/cni/static",
-  "/usr/libexec/cni/tuning",
-  "/usr/libexec/cni/vlan",
-  "/usr/libexec/cni/vrf",
-]
+dirs = [ "/usr/libexec/cni" ]
 
 [[payload.openshift-enterprise-pod-container.ignore]]
 error = "ErrNotDynLinked"

--- a/dist/releases/4.13/config.toml
+++ b/dist/releases/4.13/config.toml
@@ -38,13 +38,9 @@ files = [ "/opt/cni/bin/rhel9/openshift-sdn" ]
 
 [[payload.multus-cni-container.ignore]]
 error = "ErrNoLibcryptoSO"
-files = [
-  "/usr/src/multus-cni/rhel9/bin/multus-daemon",
-  "/usr/src/multus-cni/rhel9/bin/multus-shim",
-  "/usr/src/multus-cni/bin/multus",
-  "/usr/src/multus-cni/bin/multus-daemon",
-  "/usr/src/multus-cni/bin/multus-shim",
-  "/usr/src/multus-cni/rhel9/bin/multus",
+dirs = [
+  "/usr/src/multus-cni/rhel9/bin",
+  "/usr/src/multus-cni/bin"
 ]
 
 [[rpm.cri-tools.ignore]]
@@ -68,10 +64,7 @@ files = [
 
 [[payload.ose-multus-whereabouts-ipam-cni-container.ignore]]
 error = "ErrNoLibcryptoSO"
-files = [
-  "/usr/src/whereabouts/rhel9/bin/whereabouts",
-  "/usr/src/whereabouts/rhel9/bin/ip-control-loop",
-]
+dirs = [ "/usr/src/whereabouts/rhel9/bin" ]
 
 [[rpm.podman.ignore]]
 error = "ErrGoMissingTag"

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -74,6 +74,7 @@ func mergeLists(main, add map[string]IgnoreLists) map[string]IgnoreLists {
 type ErrIgnore struct {
 	Error KnownError `toml:"error"`
 	Files []string   `toml:"files"`
+	Dirs  []string   `toml:"dirs"`
 }
 
 type ErrIgnoreList []ErrIgnore

--- a/internal/types/types_config.go
+++ b/internal/types/types_config.go
@@ -107,6 +107,11 @@ func (i ErrIgnoreList) Ignore(file string, err error) bool {
 		if !errors.Is(err, ie.Error.Err) {
 			continue
 		}
+		for _, d := range ie.Dirs {
+			if strings.HasPrefix(file, d+"/") {
+				return true
+			}
+		}
 		for _, f := range ie.Files {
 			if file == f {
 				return true


### PR DESCRIPTION
Note that the exceptions printer won't print those.

See the commit for usage examples.