### PR TITLE
update(4.9): rm dup ignores

### DIFF
--- a/dist/releases/4.9/config.toml
+++ b/dist/releases/4.9/config.toml
@@ -1,8 +1,3 @@
-filter_files = [
-  "/usr/sbin/ldconfig",
-  "/usr/sbin/build-locale-archive"
-]
-
 [[payload.ose-egress-router-cni-alt-container.ignore]]
 error = "ErrLibcryptoSoMissing"
 files = [ "/usr/src/egress-router-cni/rhel7/bin/egress-router" ]


### PR DESCRIPTION
Those are already ignored in the top-level config.

Tested with

> scan payload -V 4.9 --url quay.io/openshift-release-dev/ocp-release:4.9.59-assembly.art7407-x86_64