### PR TITLE
chore: add /sbin/ldconfig to ignore

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -23,7 +23,7 @@ files = [ "/usr/sbin/build-locale-archive" ]
 
 [[rpm.glibc.ignore]]
 error = "ErrNotDynLinked"
-files = [ "/usr/sbin/ldconfig" ]
+files = [ "/usr/sbin/ldconfig", "/sbin/ldconfig" ]
 
 [[rpm.runc.ignore]]
 error = "ErrGoMissingTag"


### PR DESCRIPTION
In some old distros, it's /sbin/ldconfig not /usr/sbin/ldconfig, so we need to exclude both.

Found using node scan using check-payload node scan -V 4.9 --root \
  $(podman image mount quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:91e37c277d80facba198afcbb05c06c0f27b6f9c7bb4f2dd64cf12e331a0dc58)