### PR TITLE
OCPNODE-1743: Implement `--rpm-scan` for payload/image, `--walk-scan` for node scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased] - xxxx-xx-xx
+
+### Features
+
+- Add `--rpm-scan` flag to payload and image scan; if set, the scan is using
+  the same algorithm and rules as `scan node` (only scan files belonging to RPM
+  packages, and ignore per-payload and per-tag configuration entries)
+
 ## [0.3.0] - 2023-08-01
 
 This is a major release, which allows more fine-grained exceptions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   the same algorithm and rules as `scan node` (only scan files belonging to RPM
   packages, and ignore per-payload and per-tag configuration entries)
 
+### Bug fixes
+
+- Fix error text in message when logging scan node failure/warning
+
 ## [0.3.0] - 2023-08-01
 
 This is a major release, which allows more fine-grained exceptions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@
 
 ### Features
 
-- Add `--rpm-scan` flag to payload and image scan; if set, the scan is using
+- Add `--walk-scan` flag to node scan. If set, the scan is using the same
+  algorithm as `scan payload` (walk the directory tree and scan all files).
+  Note that per-payload and per-tag configuration entries are still ignored
+  because neither tag nor component is set.
+- Add `--rpm-scan` flag to payload and image scan. If set, the scan is using
   the same algorithm and rules as `scan node` (only scan files belonging to RPM
-  packages, and ignore per-payload and per-tag configuration entries)
+  packages, and ignore per-payload and per-tag configuration entries).
 
 ### Bug fixes
 

--- a/internal/scan/node_scan.go
+++ b/internal/scan/node_scan.go
@@ -59,7 +59,7 @@ func rpmRootScan(ctx context.Context, cfg *types.Config, root string) *types.Sca
 				klog.InfoS("scanning node "+status,
 					"rpm", res.RPM,
 					"path", innerPath,
-					"error", res.Error,
+					"error", res.Error.Error,
 					"status", status)
 			}
 			results.Append(res)

--- a/internal/scan/node_scan.go
+++ b/internal/scan/node_scan.go
@@ -13,6 +13,10 @@ import (
 )
 
 func RunNodeScan(ctx context.Context, cfg *types.Config, root string) []*types.ScanResults {
+	if !cfg.UseRPMScan {
+		klog.Info("scanning a directory tree")
+		return []*types.ScanResults{walkDirScan(ctx, cfg, nil, nil, root)}
+	}
 	klog.Info("scanning node")
 	return []*types.ScanResults{rpmRootScan(ctx, cfg, root)}
 }

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -227,6 +227,13 @@ func validateTag(ctx context.Context, tag *v1.TagReference, cfg *types.Config) *
 		return results.Append(types.NewScanResult().SetTag(tag).Skipped())
 	}
 
+	if cfg.UseRPMScan {
+		// Same as "scan node", essentially meaning to
+		//  - only scan files from rpms;
+		//  - skip per-tag and per-component config rules.
+		return rpmRootScan(ctx, cfg, mountPath)
+	}
+
 	// does the image contain openssl
 	opensslInfo := validations.ValidateOpenssl(ctx, mountPath)
 	results.Append(types.NewScanResult().SetOpenssl(opensslInfo).SetTag(tag))

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -15,7 +15,6 @@ type Config struct {
 	FromURL                 string        `json:"from_url"`
 	InsecurePull            bool          `json:"insecure_pull"`
 	Limit                   int           `json:"limit"`
-	NodeScan                string        `json:"node_scan"`
 	ContainerImageComponent string        `json:"container_image_component"`
 	ContainerImage          string        `json:"container_image"`
 	OutputFile              string        `json:"output_file"`
@@ -25,6 +24,7 @@ type Config struct {
 	PullSecret              string        `json:"pull_secret"`
 	TimeLimit               time.Duration `json:"time_limit"`
 	Verbose                 bool          `json:"verbose"`
+	UseRPMScan              bool          `json:"use_rpm_scan"`
 
 	ConfigFile
 }

--- a/main.go
+++ b/main.go
@@ -179,7 +179,7 @@ func main() {
 	scanPayload.Flags().Bool("rpm-scan", false, "use RPM scan (same as during node scan)")
 
 	scanNode := &cobra.Command{
-		Use:          "node [--root /myroot]",
+		Use:          "node --root /myroot [--walk-scan]",
 		SilenceUsage: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return scan.ValidateApplicationDependencies(applicationDepsNodeScan)
@@ -188,11 +188,14 @@ func main() {
 			ctx, cancel := context.WithTimeout(context.Background(), timeLimit)
 			defer cancel()
 			root, _ := cmd.Flags().GetString("root")
+			walkScan, _ := cmd.Flags().GetBool("walk-scan")
+			config.UseRPMScan = !walkScan
 			results = scan.RunNodeScan(ctx, &config, root)
 			return nil
 		},
 	}
 	scanNode.Flags().String("root", "", "root path to scan")
+	scanNode.Flags().Bool("walk-scan", false, "scan all files using directory tree walk")
 	_ = scanNode.MarkFlagRequired("root")
 
 	scanImage := &cobra.Command{

--- a/main.go
+++ b/main.go
@@ -168,6 +168,7 @@ func main() {
 				return errors.New("either -u, --url or -f, --file option is required")
 			}
 			config.PrintExceptions, _ = cmd.Flags().GetBool("print-exceptions")
+			config.UseRPMScan, _ = cmd.Flags().GetBool("rpm-scan")
 			results = scan.RunPayloadScan(ctx, &config)
 			return nil
 		},
@@ -175,6 +176,7 @@ func main() {
 	scanPayload.Flags().StringP("url", "u", "", "payload url")
 	scanPayload.Flags().StringP("file", "f", "", "payload from json file")
 	scanPayload.MarkFlagsMutuallyExclusive("url", "file")
+	scanPayload.Flags().Bool("rpm-scan", false, "use RPM scan (same as during node scan)")
 
 	scanNode := &cobra.Command{
 		Use:          "node [--root /myroot]",
@@ -185,8 +187,8 @@ func main() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithTimeout(context.Background(), timeLimit)
 			defer cancel()
-			config.NodeScan, _ = cmd.Flags().GetString("root")
-			results = scan.RunNodeScan(ctx, &config)
+			root, _ := cmd.Flags().GetString("root")
+			results = scan.RunNodeScan(ctx, &config, root)
 			return nil
 		},
 	}
@@ -204,11 +206,13 @@ func main() {
 			ctx, cancel := context.WithTimeout(context.Background(), timeLimit)
 			defer cancel()
 			config.ContainerImage, _ = cmd.Flags().GetString("spec")
+			config.UseRPMScan, _ = cmd.Flags().GetBool("rpm-scan")
 			results = scan.RunOperatorScan(ctx, &config)
 			return nil
 		},
 	}
 	scanImage.Flags().String("spec", "", "payload url")
+	scanImage.Flags().Bool("rpm-scan", false, "use RPM scan (same as during node scan)")
 	_ = scanImage.MarkFlagRequired("spec")
 
 	scanCmd.AddCommand(scanPayload)


### PR DESCRIPTION
See individual commits for details.

Surprisingly, `scan node --walk-scan` is much faster than the default mode.

Fixes: #87