### PR TITLE
chore: remove a dup from 4.13 config

### DIFF
--- a/dist/releases/4.13/config.toml
+++ b/dist/releases/4.13/config.toml
@@ -28,10 +28,6 @@ files = [ "/usr/bin/skopeo" ]
 error = "ErrLibcryptoSoMissing"
 files = [ "/usr/bin/machine-config-daemon.rhel9" ]
 
-[[rpm.containernetworking-plugins.ignore]]
-error = "ErrGoMissingTag"
-files = [ "/usr/libexec/cni/dummy" ]
-
 [[payload.ose-node-container.ignore]]
 error = "ErrLibcryptoSoMissing"
 files = [ "/opt/cni/bin/rhel9/openshift-sdn" ]


### PR DESCRIPTION
This is already excluded by main config.toml:

> [[rpm.containernetworking-plugins.ignore]]
> error = "ErrGoMissingTag"
> dirs = [ "/usr/libexec/cni" ]