### PR TITLE
Config validation fixups

### DIFF
--- a/dist/releases/config_test.go
+++ b/dist/releases/config_test.go
@@ -42,5 +42,10 @@ func TestConfigs(t *testing.T) {
 		if err != nil {
 			t.Errorf("%s config has duplicates: %v", dir, err)
 		}
+		// Re-validate the combined config.
+		if err, warn := main.Validate(); err != nil || warn != nil {
+			t.Errorf("main+%s combined config failed validation: errors: %v; warnings: %v", dir, err, warn)
+		}
+
 	}
 }

--- a/dist/releases/config_test.go
+++ b/dist/releases/config_test.go
@@ -31,12 +31,12 @@ func TestConfigs(t *testing.T) {
 		if i == 0 { // Validate main config only once.
 			err, warn := main.Validate()
 			if err != nil || warn != nil {
-				t.Errorf("main config validation failed: %v; %v", err, warn)
+				t.Errorf("main config validation failed: errors: %v; warnings: %v", err, warn)
 			}
 		}
 		add := decodeConfig(t, dir+"/config.toml")
 		if err, warn := add.Validate(); err != nil || warn != nil {
-			t.Errorf("%s config failed validation: %v; %v", dir, err, warn)
+			t.Errorf("%s config failed validation: errors: %v; warnings: %v", dir, err, warn)
 		}
 		err := main.Add(add)
 		if err != nil {

--- a/internal/types/types_config_file.go
+++ b/internal/types/types_config_file.go
@@ -119,9 +119,6 @@ func validateOverlaps(listname string, perr *error, files, dirs []string) {
 	// Now, check that files do not overlap with any dirs.
 	for i := range files {
 		for j := range dirs {
-			if i == j {
-				continue
-			}
 			if strings.HasPrefix(files[i], dirs[j]+"/") {
 				multierr.AppendInto(perr, &errOverlap{listname + "files", files[i], dirs[j]})
 			}


### PR DESCRIPTION
With this fix, the config validation now properly detects the dupe that was
fixed earlier in commit a8c7f00 / PR #106 (which it failed to detect before).

With that commit reverted, the failure looks like this:

> === RUN   TestConfigs
>     config_test.go:47: main+4.13 combined config failed validation: errors: <nil>; warnings: config entry [[rpm.containernetworking-plugins.ignore]].error=ErrGoMissingTag.files contains a redundant path "/usr/libexec/cni/dummy", overlapped by "/usr/libexec/cni"
> --- FAIL: TestConfigs (0.00s)