### PR TITLE
add Java / JDK image scan option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 check-payload
 bin/
+*.class

--- a/README.md
+++ b/README.md
@@ -138,6 +138,14 @@ Golang validations run through a pipeline:
 1. validateGoOpenssl - ensure openssl matches the dynamic library within the system
 1. validateGoTags - ensure golang tags are set
 
+#### Java Development Kit
+
+JDK validations run through a pipeline:
+
+1. validateFipsHost - ensures the `check-payload` tool is being run on a FIPS enabled host
+1. validateSystemProperties - ensures pertinent [FIPS property values](https://access.redhat.com/documentation/en-us/openjdk/8/html/configuring_openjdk_8_on_rhel_with_fips/config-fips-in-openjdk) are not being set at runtime
+1. validateAlgorithms - ensures unacceptable algorithms and protocols are disabled at runtime
+
 ### Printer
 
 The printer aggregates all the results and formats into a table, csv, markdown, etc. If any errors are found then the process exits non-zero. A successful run returns 0.

--- a/config.toml
+++ b/config.toml
@@ -17,6 +17,17 @@ filter_dirs = [
   "/sysroot",
 ]
 
+java_fips_disabled_algorithms = [
+  "DH keySize < 2048", "TLSv1.1", "TLSv1", "SSLv3", "SSLv2",
+  "TLS_RSA_WITH_AES_256_CBC_SHA256", "TLS_RSA_WITH_AES_256_CBC_SHA",
+  "TLS_RSA_WITH_AES_128_CBC_SHA256", "TLS_RSA_WITH_AES_128_CBC_SHA",
+  "TLS_RSA_WITH_AES_256_GCM_SHA384", "TLS_RSA_WITH_AES_128_GCM_SHA256",
+  "DHE_DSS", "RSA_EXPORT", "DHE_DSS_EXPORT", "DHE_RSA_EXPORT",
+  "DH_DSS_EXPORT", "DH_RSA_EXPORT", "DH_anon", "ECDH_anon", "DH_RSA",
+  "DH_DSS", "ECDH", "3DES_EDE_CBC", "DES_CBC", "RC4_40", "RC4_128",
+  "DES40_CBC", "RC2", "HmacMD5",
+]
+
 [[rpm.glibc-common.ignore]]
 error = "ErrNotDynLinked"
 files = [ "/usr/sbin/build-locale-archive" ]

--- a/dist/releases/embeds.go
+++ b/dist/releases/embeds.go
@@ -3,14 +3,19 @@ package releases
 import (
 	"embed"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sort"
+	"strings"
+	"syscall"
 
 	semver "github.com/Masterminds/semver/v3"
 )
 
 //go:embed */*
 var configs embed.FS
+
+const JavaFips = "FIPS.java"
 
 // GetVersions returns the list of versions for those embedded configs
 // are available.
@@ -19,9 +24,11 @@ func GetVersions() []string {
 	if err != nil { // Should not happen.
 		return nil
 	}
-	names := make([]string, len(dirs))
-	for i, d := range dirs {
-		names[i] = d.Name()
+	names := make([]string, 0, len(dirs))
+	for _, d := range dirs {
+		if name := d.Name(); name != "java" {
+			names = append(names, name)
+		}
 	}
 	sort.Slice(names, func(i, j int) bool {
 		v1, _ := semver.NewVersion(names[i])
@@ -39,4 +46,43 @@ func GetConfigFor(version string) ([]byte, error) {
 	}
 
 	return nil, fmt.Errorf("embedded config for version %s is not available; use one of %+v", version, GetVersions())
+}
+
+// GetJavaFile returns the java source file.
+func GetJavaFile() (fileFullPath, fileName string, err error) {
+	bytes, err := configs.ReadFile("java/" + JavaFips)
+	if err != nil {
+		return "", "", err
+	}
+
+	return createTempFile(bytes, "fipsJava")
+}
+
+// GetAlgorithmFile returns a file with disabled algorithms to check.
+func GetAlgorithmFile(javaDisabledAlgorithms []string) (fileFullPath, fileName string, err error) {
+	return createTempFile([]byte(strings.Join(javaDisabledAlgorithms, "\n")), "disabledAlgorithms")
+}
+
+// createTempFile returns a temporary file with specified content and prefix, created in the OS's default temp folder.
+// Closing of the file (defer os.Remove(file.Name())) is the caller's responsibility.
+func createTempFile(content []byte, prefix string) (fileFullPath, fileName string, err error) {
+	file, err := os.CreateTemp("", prefix)
+	if err != nil {
+		return "", "", err
+	}
+	defer func() {
+		if err != nil {
+			os.Remove(file.Name())
+		}
+	}()
+	fileModeRO := os.FileMode(syscall.S_IRUSR | syscall.S_IRGRP | syscall.S_IROTH)
+	if err = file.Chmod(fileModeRO); err != nil {
+		return "", "", err
+	}
+	_, err = file.Write(content)
+	if err != nil {
+		return "", "", err
+	}
+
+	return file.Name(), filepath.Base(file.Name()), nil
 }

--- a/dist/releases/java/FIPS.java
+++ b/dist/releases/java/FIPS.java
@@ -1,0 +1,99 @@
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.Security;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class FIPS {
+
+  public static void main(String[] args) {
+    // Exit code 8 is used to differentiate valid scan returns.
+    if (validateFipsHost())
+      System.exit(8);
+
+    if (validateSystemProperties())
+      System.exit(8);
+
+    if (validateAlgorithms(args))
+      System.exit(8);
+  }
+
+  // validate that the tool is running on a FIPS enabled host
+  public static boolean validateFipsHost() {
+    String content = null;
+    try {
+      byte[] fileBytes = Files.readAllBytes(Paths.get("/proc/sys/crypto/fips_enabled"));
+      content = new String(fileBytes, StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    int fileInt = Integer.parseInt(content.trim());
+    if (fileInt != 1) {
+      System.err.println("java scan must be run on a FIPS enabled host");
+      return true;
+    }
+    return false;
+  }
+
+  // https://access.redhat.com/documentation/en-us/openjdk/8/html/configuring_openjdk_8_on_rhel_with_fips/config-fips-in-openjdk
+  public static boolean validateSystemProperties() {
+    Boolean prop1 = validateSystemProperty("security.useSystemPropertiesFile", "false");
+    Boolean prop2 = validateSystemProperty("java.security.disableSystemPropertiesFile", "true");
+    Boolean prop3 = validateSystemProperty("com.redhat.fips", "false");
+    if (prop1 || prop2 || prop3)
+      return true;
+
+    return false;
+  }
+
+  public static boolean validateSystemProperty(String property, String value) {
+    String str = System.getProperty(property);
+    if (str != null && str.equals(value)) {
+      System.err.append("java property '" + property + "' should not be set to " + value + "\n");
+      return true;
+    }
+    return false;
+  }
+
+  public static boolean validateAlgorithms(String[] args) {
+    ArrayList<String> ar = new ArrayList<String>();
+    if (args.length > 0) {
+      BufferedReader reader;
+      try {
+        reader = new BufferedReader(new FileReader(args[0]));
+        String line = null;
+        while ((line = reader.readLine()) != null) {
+          ar.add(line);
+        }
+        reader.close();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    String disabledAlgorithms[] = ar.toArray(new String[ar.size()]);
+    List<String> disAlgor = Arrays.asList(Security.getProperty("jdk.tls.disabledAlgorithms").trim().split(","));
+    List<String> trimmedDisAlgor = disAlgor.stream().map(String::trim).collect(Collectors.toList());
+    System.out.println("jdk.tls.disabledAlgorithms: " + trimmedDisAlgor.toString());
+    System.out.println("Total disabled algorithms = " + trimmedDisAlgor.size());
+
+    List<String> reqDisAlgList = Arrays.asList(disabledAlgorithms);
+    System.out.println("Checking for these disabled algorithms = " + reqDisAlgList.toString());
+    System.out.println("Total algorithms being checked = " + reqDisAlgList.size());
+
+    Boolean result = false;
+    for (int i = 0; i < disabledAlgorithms.length; i++) {
+      if (!trimmedDisAlgor.contains(disabledAlgorithms[i])) {
+        System.err.append("algorithm '" + disabledAlgorithms[i] + "' should be disabled\n");
+        result = true;
+      }
+    }
+    return result;
+  }
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -20,6 +20,7 @@ type Config struct {
 	OutputFile              string        `json:"output_file"`
 	OutputFormat            string        `json:"output_format"`
 	Parallelism             int           `json:"parallelism"`
+	Java                    bool          `json:"java"`
 	PrintExceptions         bool          `json:"print_exceptions"`
 	PullSecret              string        `json:"pull_secret"`
 	TimeLimit               time.Duration `json:"time_limit"`
@@ -32,9 +33,10 @@ type Config struct {
 // ConfigFile is a part of Config. It contains fields that can be set via a
 // configuration files.
 type ConfigFile struct {
-	FilterFiles  []string `json:"filter_files" toml:"filter_files"`
-	FilterDirs   []string `json:"filter_dirs" toml:"filter_dirs"`
-	FilterImages []string `json:"filter_images" toml:"filter_images"`
+	FilterFiles            []string `json:"filter_files" toml:"filter_files"`
+	FilterDirs             []string `json:"filter_dirs" toml:"filter_dirs"`
+	FilterImages           []string `json:"filter_images" toml:"filter_images"`
+	JavaDisabledAlgorithms []string `json:"java_fips_disabled_algorithms" toml:"java_fips_disabled_algorithms"`
 
 	PayloadIgnores map[string]IgnoreLists `toml:"payload"`
 	TagIgnores     map[string]IgnoreLists `toml:"tag"`
@@ -79,6 +81,12 @@ type OpenshiftComponent struct {
 	SourceLocation      string `json:"source_location"`
 	MaintainerComponent string `json:"maintainer_component"`
 	IsBundle            bool   `json:"is_bundle"`
+}
+
+type JavaComponent struct {
+	Entrypoint []string
+	Cmd        []string
+	WorkingDir string
 }
 
 type OpensslInfo struct {

--- a/internal/validations/validations.go
+++ b/internal/validations/validations.go
@@ -33,6 +33,12 @@ var (
 	}
 
 	goLessThan118 = newSemverConstraint("< 1.18")
+
+	// correlates to java 1.8
+	JavaClassLessThan52 = newSemverConstraint("< 52")
+
+	// correlates to java 1.11
+	JavaClassLessThan55 = newSemverConstraint("< 55")
 )
 
 type Baton struct {


### PR DESCRIPTION
```bash
% sudo ./check-payload scan java -h               
Usage:
  check-payload scan java-image [image pull spec] [flags]

Aliases:
  java-image, java

Flags:
      --disabled-algorithms strings   additional algorithms that java should be disabling in FIPS mode
  -h, --help                          help for java-image
      --rpm-scan                      use RPM scan (same as during node scan)
      --spec string                   java payload url
```
Requirements to run -
 - FIPS enabled host. This is required in order to verify java is properly configured for FIPS at runtime. 
 - Scans images w/ jdk 1.8+ installed

example printer outputs -
```
---- Failure Report
+----------------------------------------------+--------------------------------------------+
| STATUS                                       | IMAGE                                      |
+----------------------------------------------+--------------------------------------------+
| java scan must be run on a FIPS enabled host | registry.access.redhat.com/ubi8/openjdk-11 |
|                                              |                                            |
+----------------------------------------------+--------------------------------------------+
```
```
---- Failure Report
+-----------------------------------------------------------------------------+--------------------------------------------+
| STATUS                                                                      | IMAGE                                      |
+-----------------------------------------------------------------------------+--------------------------------------------+
| java property 'security.useSystemPropertiesFile' should not be set to false | registry.access.redhat.com/ubi8/openjdk-11 |
| java property 'com.redhat.fips' should not be set to false                  |                                            |
|                                                                             |                                            |
+-----------------------------------------------------------------------------+--------------------------------------------+
```
```
---- Failure Report
+----------------------------------------------------------------+----------------------+
| STATUS                                                         | IMAGE                |
+----------------------------------------------------------------+----------------------+
| algorithm 'DH keySize < 2048' should be disabled               | docker.io/openjdk:10 |
| algorithm 'TLSv1.1' should be disabled                         |                      |
| algorithm 'TLSv1' should be disabled                           |                      |
| algorithm 'SSLv2' should be disabled                           |                      |
| algorithm 'TLS_RSA_WITH_AES_256_CBC_SHA256' should be disabled |                      |
| algorithm 'TLS_RSA_WITH_AES_256_CBC_SHA' should be disabled    |                      |
| algorithm 'TLS_RSA_WITH_AES_128_CBC_SHA256' should be disabled |                      |
| algorithm 'TLS_RSA_WITH_AES_128_CBC_SHA' should be disabled    |                      |
| algorithm 'TLS_RSA_WITH_AES_256_GCM_SHA384' should be disabled |                      |
| algorithm 'TLS_RSA_WITH_AES_128_GCM_SHA256' should be disabled |                      |
| algorithm 'DHE_DSS' should be disabled                         |                      |
| algorithm 'RSA_EXPORT' should be disabled                      |                      |
| algorithm 'DHE_DSS_EXPORT' should be disabled                  |                      |
| algorithm 'DHE_RSA_EXPORT' should be disabled                  |                      |
| algorithm 'DH_DSS_EXPORT' should be disabled                   |                      |
| algorithm 'DH_RSA_EXPORT' should be disabled                   |                      |
| algorithm 'DH_anon' should be disabled                         |                      |
| algorithm 'ECDH_anon' should be disabled                       |                      |
| algorithm 'DH_RSA' should be disabled                          |                      |
| algorithm 'DH_DSS' should be disabled                          |                      |
| algorithm 'ECDH' should be disabled                            |                      |
| algorithm 'DES_CBC' should be disabled                         |                      |
| algorithm 'RC4_128' should be disabled                         |                      |
| algorithm 'RC2' should be disabled                             |                      |
| algorithm 'HmacMD5' should be disabled                         |                      |
|                                                                |                      |
+----------------------------------------------------------------+----------------------+
```
```
$ sudo ./check-payload scan java --spec registry.access.redhat.com/ubi8/openjdk-17 --disabled-algorithms TESTING,THIS
........
---- Failure Report
+----------------------------------------+--------------------------------------------+
| STATUS                                 | IMAGE                                      |
+----------------------------------------+--------------------------------------------+
| algorithm 'TESTING' should be disabled | registry.access.redhat.com/ubi8/openjdk-17 |
| algorithm 'THIS' should be disabled    |                                            |
|                                        |                                            |
+----------------------------------------+--------------------------------------------+
```
```
---- Failure Report
+-----------------------------------+---------------------+
| STATUS                            | IMAGE               |
+-----------------------------------+---------------------+
| this scan tool supports java 1.8+ | docker.io/openjdk:7 |
+-----------------------------------+---------------------+
```
```
---- Warning Report
+-----------------------------+---------------------------+
| STATUS                      | IMAGE                     |
+-----------------------------+---------------------------+
| openssl library not present | quay.io/keycloak/keycloak |
+-----------------------------+---------------------------+
---- Successful run with warnings
```
_Future enhancements?_
 - _Handle/parse entrypoint wrapper scripts. We currently ignore them if set._
 - _Support JRE image scans. This would require precompiled java code (per java version), which we could embed within the check-payload binary._
