### PR TITLE
config.toml: add exception for rukpak

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -78,3 +78,6 @@ files = [ "/usr/bin/pod" ]
 
 [payload.operator-lifecycle-manager-container]
 filter_files = [ "/usr/bin/cpb" ]
+
+[payload.ose-olm-rukpak-container]
+filter_files = [ "/unpack" ]


### PR DESCRIPTION
Joe Lanford says:

> We copy this binary into a scratch image, so it needs to be statically
> compiled. It does not do any crypto.

Since this binary will also be in a future releases, place it in a global config.

Tested with:
```console
$ ./check-payload scan payload -u registry.ci.openshift.org/ocp/release:4.14.0-0.nightly-2023-09-21-002530 -V 4.14
...
---- Successful run
```