### PR TITLE
exclude a statically-compiled utility for OLM

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -77,7 +77,10 @@ error = "ErrNotDynLinked"
 files = [ "/usr/bin/pod" ]
 
 [payload.operator-lifecycle-manager-container]
-filter_files = [ "/usr/bin/cpb" ]
+filter_files = [
+  "/usr/bin/cpb",
+  "/usr/bin/copy-content",
+]
 
 [payload.ose-olm-rukpak-container]
 filter_files = [ "/unpack" ]


### PR DESCRIPTION
In 4.15+, OLM will not require that users provide an `opm` binary with their index image. In cases where they do not, OLM simply copies the catalog data from their index image and uses it directly. In order to copy this data, we do not want to assume anything about the image that contains the content we need to copy, so we statically compile a utility that helps us copy the data around, instead of assuming the image has `sh` or `cp`.