### PR TITLE
config: exclude ovnkube-trace for 4.14

### DIFF
--- a/dist/releases/4.14/config.toml
+++ b/dist/releases/4.14/config.toml
@@ -26,7 +26,10 @@ dirs = [
 
 [[payload.ose-ovn-kubernetes-container.ignore]]
 error = "ErrLibcryptoSoMissing"
-files = [ "/usr/libexec/cni/rhel8/ovn-k8s-cni-overlay" ]
+files = [
+  "/usr/libexec/cni/rhel8/ovn-k8s-cni-overlay",
+  "/usr/lib/rhel8/ovnkube-trace"
+]
 
 [[payload.ose-egress-router-cni-container.ignore]]
 error = "ErrLibcryptoSoMissing"


### PR DESCRIPTION
Got this error while scanning a recent 4.14 nightly (4.14.0-0.nightly-2023-10-24-154330):

> "scanning failed" image="quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:5bd6ea4bccb3728221fce0c3942ae53270d6897222193c3dedc594912b714d93" path="/usr/lib/rhel8/ovnkube-trace" error="could not find dependent openssl version within container image: libcrypto.so.1.1" component="ose-ovn-kubernetes-container" tag="ovn-kubernetes" rpm="" status="failed"

Obviously, this is another case of a binary which is targeted for a distro other than this container.

Add it to the exclusions for 4.14.