### PR TITLE
bump: for image creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug fixes
 
 - Chore: remove cliff.toml configuration
+- Bump: for OpenShift image creation
 
 ## [0.3.1] - 2023-08-04
 


### PR DESCRIPTION
The CI promotion PR (https://github.com/openshift/release/pull/43529) merged, but we need to promote an image. This PR is a no-op to promote the image.