### PR TITLE
Add opm so that we can run the operator index image check in the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,10 @@ RUN make
 
 FROM registry.ci.openshift.org/ocp/4.14:base-rhel9
 RUN dnf -y update && dnf install -y binutils file go podman && dnf clean all
+RUN curl --fail --retry 3 -LJO https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest-4.14/opm-linux.tar.gz && \
+    tar -xzf opm-linux.tar.gz && \
+    mv ./opm /usr/local/bin/ && \
+    rm -f opm-linux.tar.gz
 COPY --from=builder /app/check-payload /check-payload
 
 ENTRYPOINT ["/check-payload"]


### PR DESCRIPTION
Add opm so that we can run the operator index image check in the container.
Doc for opm installation: https://docs.openshift.com/container-platform/4.14/cli_reference/opm/cli-opm-install.html