### PR TITLE
OCPBUGS-24612: check for goexperimental >= 1.18

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -18,27 +18,48 @@ filter_dirs = [
 ]
 
 java_fips_disabled_algorithms = [
-  "DH keySize < 2048", "TLSv1.1", "TLSv1", "SSLv3", "SSLv2",
-  "TLS_RSA_WITH_AES_256_CBC_SHA256", "TLS_RSA_WITH_AES_256_CBC_SHA",
-  "TLS_RSA_WITH_AES_128_CBC_SHA256", "TLS_RSA_WITH_AES_128_CBC_SHA",
-  "TLS_RSA_WITH_AES_256_GCM_SHA384", "TLS_RSA_WITH_AES_128_GCM_SHA256",
-  "DHE_DSS", "RSA_EXPORT", "DHE_DSS_EXPORT", "DHE_RSA_EXPORT",
-  "DH_DSS_EXPORT", "DH_RSA_EXPORT", "DH_anon", "ECDH_anon", "DH_RSA",
-  "DH_DSS", "ECDH", "3DES_EDE_CBC", "DES_CBC", "RC4_40", "RC4_128",
-  "DES40_CBC", "RC2", "HmacMD5",
+  "DH keySize < 2048",
+  "TLSv1.1",
+  "TLSv1",
+  "SSLv3",
+  "SSLv2",
+  "TLS_RSA_WITH_AES_256_CBC_SHA256",
+  "TLS_RSA_WITH_AES_256_CBC_SHA",
+  "TLS_RSA_WITH_AES_128_CBC_SHA256",
+  "TLS_RSA_WITH_AES_128_CBC_SHA",
+  "TLS_RSA_WITH_AES_256_GCM_SHA384",
+  "TLS_RSA_WITH_AES_128_GCM_SHA256",
+  "DHE_DSS",
+  "RSA_EXPORT",
+  "DHE_DSS_EXPORT",
+  "DHE_RSA_EXPORT",
+  "DH_DSS_EXPORT",
+  "DH_RSA_EXPORT",
+  "DH_anon",
+  "ECDH_anon",
+  "DH_RSA",
+  "DH_DSS",
+  "ECDH",
+  "3DES_EDE_CBC",
+  "DES_CBC",
+  "RC4_40",
+  "RC4_128",
+  "DES40_CBC",
+  "RC2",
+  "HmacMD5",
 ]
 
 [[rpm.glibc-common.ignore]]
 error = "ErrNotDynLinked"
-files = [ "/usr/sbin/build-locale-archive" ]
+files = ["/usr/sbin/build-locale-archive"]
 
 [[rpm.glibc.ignore]]
 error = "ErrNotDynLinked"
-files = [ "/usr/sbin/ldconfig", "/sbin/ldconfig" ]
+files = ["/usr/sbin/ldconfig", "/sbin/ldconfig"]
 
 [[rpm.runc.ignore]]
 error = "ErrGoMissingTag"
-files = [ "/usr/bin/runc" ]
+files = ["/usr/bin/runc"]
 
 [[rpm.podman.ignore]]
 error = "ErrGoMissingTag"
@@ -50,48 +71,42 @@ files = [
 
 [[rpm.podman.ignore]]
 error = "ErrNotDynLinked"
-files = [ "/usr/libexec/podman/catatonit" ]
+files = ["/usr/libexec/podman/catatonit"]
 
 [[rpm.podman-catatonit.ignore]]
 error = "ErrNotDynLinked"
-files = [ "/usr/libexec/catatonit/catatonit" ]
+files = ["/usr/libexec/catatonit/catatonit"]
 
 [[rpm.skopeo.ignore]]
 error = "ErrGoMissingTag"
-files = [ "/usr/bin/skopeo" ]
+files = ["/usr/bin/skopeo"]
 
 [[rpm.cri-o.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/crio",
-  "/usr/bin/crio-status",
-]
+files = ["/usr/bin/crio", "/usr/bin/crio-status"]
 
 [[rpm.cri-o.ignore]]
 error = "ErrNotDynLinked"
-files = [ "/usr/bin/pinns" ]
+files = ["/usr/bin/pinns"]
 
 [[rpm.cri-tools.ignore]]
 error = "ErrGoMissingTag"
-files = [ "/usr/bin/crictl" ]
+files = ["/usr/bin/crictl"]
 
 [[rpm.containernetworking-plugins.ignore]]
 error = "ErrGoMissingTag"
-dirs = [ "/usr/libexec/cni" ]
+dirs = ["/usr/libexec/cni"]
 
 [[rpm.ignition.ignore]]
 error = "ErrGoMissingTag"
-files = [ "/usr/lib/dracut/modules.d/30ignition/ignition" ]
+files = ["/usr/lib/dracut/modules.d/30ignition/ignition"]
 
 [[payload.openshift-enterprise-pod-container.ignore]]
 error = "ErrNotDynLinked"
-files = [ "/usr/bin/pod" ]
+files = ["/usr/bin/pod"]
 
 [payload.operator-lifecycle-manager-container]
-filter_files = [
-  "/usr/bin/cpb",
-  "/usr/bin/copy-content",
-]
+filter_files = ["/usr/bin/cpb", "/usr/bin/copy-content"]
 
 [payload.ose-olm-rukpak-container]
-filter_files = [ "/unpack" ]
+filter_files = ["/unpack"]

--- a/dist/releases/4.14/config.toml
+++ b/dist/releases/4.14/config.toml
@@ -1,34 +1,28 @@
 [[payload.ose-network-interface-bond-cni-container.ignore]]
 error = "ErrLibcryptoSoMissing"
-files = [
-  "/bondcni/bond",
-  "/bondcni/rhel9/bond",
-]
+files = ["/bondcni/bond", "/bondcni/rhel9/bond"]
 
 [[payload.ose-network-tools-container.ignore]]
 error = "ErrLibcryptoSoMissing"
-files = [ "/usr/bin/ovnkube-trace" ]
+files = ["/usr/bin/ovnkube-trace"]
 
 [[payload.ose-machine-config-operator-container.ignore]]
 error = "ErrLibcryptoSoMissing"
-files = [ "/usr/bin/machine-config-daemon.rhel9" ]
+files = ["/usr/bin/machine-config-daemon.rhel9"]
 
 [[payload.ose-node-container.ignore]]
 error = "ErrLibcryptoSoMissing"
-files = [ "/opt/cni/bin/rhel9/openshift-sdn" ]
+files = ["/opt/cni/bin/rhel9/openshift-sdn"]
 
 [[payload.multus-cni-container.ignore]]
 error = "ErrLibcryptoSoMissing"
-dirs = [
-  "/usr/src/multus-cni/rhel9/bin",
-  "/usr/src/multus-cni/bin",
-]
+dirs = ["/usr/src/multus-cni/rhel9/bin", "/usr/src/multus-cni/bin"]
 
 [[payload.ose-ovn-kubernetes-container.ignore]]
 error = "ErrLibcryptoSoMissing"
 files = [
   "/usr/libexec/cni/rhel8/ovn-k8s-cni-overlay",
-  "/usr/lib/rhel8/ovnkube-trace"
+  "/usr/lib/rhel8/ovnkube-trace",
 ]
 
 [[payload.ose-egress-router-cni-container.ignore]]
@@ -40,7 +34,19 @@ files = [
 
 [[payload.ose-multus-whereabouts-ipam-cni-container.ignore]]
 error = "ErrLibcryptoSoMissing"
-dirs = [
-  "/usr/src/whereabouts/bin",
-  "/usr/src/whereabouts/rhel9/bin",
-]
+dirs = ["/usr/src/whereabouts/bin", "/usr/src/whereabouts/rhel9/bin"]
+
+
+[[payload.ose-ovn-kubernetes-container.ignore]]
+error = "ErrGoNotGoExperiment"
+dirs = ["/usr/libexec/cni"]
+
+
+[[payload.ose-agent-installer-node-agent-container.ignore]]
+error = "ErrGoNotGoExperiment"
+files = ["/usr/bin/podman"]
+dirs = ["/usr/libexec/podman"]
+
+[[payload.openshift-enterprise-builder-container.ignore]]
+error = "ErrGoNotGoExperiment"
+files = ["/usr/bin/runc"]

--- a/internal/types/error_map.go
+++ b/internal/types/error_map.go
@@ -9,6 +9,7 @@ var KnownErrors = map[string]error {
 	"ErrGoNoCgoInit": ErrGoNoCgoInit,
 	"ErrGoNoTags": ErrGoNoTags,
 	"ErrGoNotCgoEnabled": ErrGoNotCgoEnabled,
+	"ErrGoNotGoExperiment": ErrGoNotGoExperiment,
 	"ErrLibcryptoMany": ErrLibcryptoMany,
 	"ErrLibcryptoMissing": ErrLibcryptoMissing,
 	"ErrLibcryptoSoMissing": ErrLibcryptoSoMissing,

--- a/internal/types/errors.go
+++ b/internal/types/errors.go
@@ -13,6 +13,7 @@ var (
 	ErrGoNoCgoInit        = errors.New("x_cgo_init not found")
 	ErrGoNoTags           = errors.New("go binary has no build tags set (should have strictfipsruntime)")
 	ErrGoNotCgoEnabled    = errors.New("go binary is not CGO_ENABLED")
+	ErrGoNotGoExperiment  = errors.New("go binary does not enable GOEXPERIMENT=strictfipsruntime")
 	ErrLibcryptoMany      = errors.New("openssl: found multiple different libcrypto versions")
 	ErrLibcryptoMissing   = errors.New("openssl: did not find libcrypto library within binary")
 	ErrLibcryptoSoMissing = errors.New("could not find dependent openssl version within container image")


### PR DESCRIPTION
Check for goexperimental with golang >= 1.18.

Fixed #81 