### PR TITLE
Adding /usr/bin/tini-static back to the ignore list

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -49,6 +49,10 @@ java_fips_disabled_algorithms = [
   "HmacMD5",
 ]
 
+[[rpm.tini.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/bin/tini-static"]
+
 [[rpm.glibc-common.ignore]]
 error = "ErrNotDynLinked"
 files = ["/usr/sbin/build-locale-archive"]


### PR DESCRIPTION
It was probably removed by accident via https://github.com/openshift/check-payload/commit/99877fc3a64433482777306442c600e5802c51d7