### PR TITLE
Add exception for bond cni RHEL 8 binary in RHEL 9 base

### DIFF
--- a/dist/releases/4.16/config.toml
+++ b/dist/releases/4.16/config.toml
@@ -62,3 +62,7 @@ dirs = ["/usr/src/whereabouts/rhel8/bin"]
 [[payload.oc-mirror-plugin-container.ignore]]
 error = "ErrLibcryptoSoMissing"
 files = ["/usr/bin/oc-mirror.rhel8"]
+
+[[payload.ose-network-interface-bond-cni-container.ignore]]
+error = "ErrLibcryptoSoMissing"
+files = ["/bondcni/rhel8/bond"]


### PR DESCRIPTION
https://github.com/openshift/bond-cni/blob/release-4.16/Dockerfile.openshift copies RHEL 8 binary to RHEL 9 base
