### PR TITLE
update 4.15 ignores

### DIFF
--- a/dist/releases/4.15/config.toml
+++ b/dist/releases/4.15/config.toml
@@ -50,3 +50,11 @@ dirs = ["/usr/libexec/podman"]
 [[payload.openshift-enterprise-builder-container.ignore]]
 error = "ErrGoNotGoExperiment"
 files = ["/usr/bin/runc"]
+
+[[payload.oc-mirror-plugin-container.ignore]]
+error = "ErrLibcryptoSoMissing"
+files = ["/usr/bin/oc-mirror.rhel8"]
+
+[[payload.ose-node-container.ignore]]
+error = "ErrLibcryptoSoMissing"
+files = ["/opt/cni/bin/rhel8/openshift-sdn"]


### PR DESCRIPTION
Follows https://github.com/openshift/check-payload/pull/168

4.15 scan result against payload `quay.io/openshift-release-dev/ocp-release:4.15.8-x86_64`
```
| OPERATOR NAME              | TAG NAME  | EXECUTABLE NAME                  | STATUS                                                                            | IMAGE                                                                                                                  |
+----------------------------+-----------+----------------------------------+-----------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| oc-mirror-plugin-container | oc-mirror | /usr/bin/oc-mirror.rhel8         | could not find dependent openssl version within container image: libcrypto.so.1.1 | quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d721073a7f5bee15cb5b265804d1070bdc9e3d7edc7196c0c2958f2fbe975ccb |
| ose-node-container         | sdn       | /opt/cni/bin/rhel8/openshift-sdn | could not find dependent openssl version within container image: libcrypto.so.1.1 | quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:00dce56c49276ae15f087d7cc974d393f88ed55f803193ad6c44ae35927687b0 |
```
oc-mirror: https://github.com/openshift/oc-mirror/blob/release-4.15/images/cli/Dockerfile.ci
sdn: https://github.com/openshift/sdn/blob/release-4.15/images/sdn/Dockerfile.rhel