### PR TITLE
Update docs to reference correct bundle directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ Here:
 #### Example
 
 ```sh
-./check-payload scan local --path ./test/resources/bundle-1
+./check-payload scan local --path ./test/resources/mock_unpacked_dir-1
 ```
 
-This command will scan the local image bundle located in `./test/resources/bundle-1`.
+This command will scan the local image bundle located in `./test/resources/mock_unpacked_dir-1`.
 
 #### Use Case
 


### PR DESCRIPTION
A recent change refactored the bundle directory naming and structure, but we're still using the old names in the README.

  https://github.com/openshift/check-payload/commit/d21f5cdc51824f5c270bd8c0ce8d8f5af679161b

This commit updates the doc to align with what's in tree.