### PR TITLE
volsync-container exception for diskrsync binary

### DIFF
--- a/dist/releases/4.15/config.toml
+++ b/dist/releases/4.15/config.toml
@@ -58,3 +58,18 @@ files = ["/usr/bin/oc-mirror.rhel8"]
 [[payload.ose-node-container.ignore]]
 error = "ErrLibcryptoSoMissing"
 files = ["/opt/cni/bin/rhel8/openshift-sdn"]
+
+# VolSync packages diskrsync which uses x/crypto/blake2b for local hashing only
+# for comparing blocks of data (non-cryptographic)
+# Actual network transfer is handled by the ssh executable in the image
+[[payload.volsync-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/local/bin/diskrsync"]
+
+[[payload.volsync-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/local/bin/diskrsync"]
+
+[[payload.volsync-container.ignore]]
+error = "ErrLibcryptoMissing"
+files = ["/usr/local/bin/diskrsync"]

--- a/dist/releases/4.16/config.toml
+++ b/dist/releases/4.16/config.toml
@@ -66,3 +66,18 @@ files = ["/usr/bin/oc-mirror.rhel8"]
 [[payload.ose-network-interface-bond-cni-container.ignore]]
 error = "ErrLibcryptoSoMissing"
 files = ["/bondcni/rhel8/bond"]
+
+# VolSync packages diskrsync which uses x/crypto/blake2b for local hashing only
+# for comparing blocks of data (non-cryptographic)
+# Actual network transfer is handled by the ssh executable in the image
+[[payload.volsync-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/local/bin/diskrsync"]
+
+[[payload.volsync-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/local/bin/diskrsync"]
+
+[[payload.volsync-container.ignore]]
+error = "ErrLibcryptoMissing"
+files = ["/usr/local/bin/diskrsync"]


### PR DESCRIPTION

VolSync packages diskrsync which uses  x/crypto/blake2b for non-cryptographic use (local hashing).

It then never calls out to code to do any network transfers (will exec the ssh executable on the image itself for transferring files), so also does not build dynamically.

Looking to exclude disksync from the check-payload scanner for OpenShift v4.15 and up.