### PR TITLE
Update 4.11 exclude

### DIFF
--- a/dist/releases/4.11/config.toml
+++ b/dist/releases/4.11/config.toml
@@ -1,0 +1,7 @@
+[[payload.openshift-enterprise-operator-sdk-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/lib/golang/pkg/tool/linux_amd64/cgo"]
+
+[[payload.openshift-enterprise-operator-sdk-container.ignore]]
+error = "ErrLibcryptoMissing"
+files = ["/usr/lib/golang/pkg/tool/linux_amd64/cgo"]


### PR DESCRIPTION
**Build**: openshift-enterprise-operator-sdk-container-v4.11.0-202405110035.p0.g802a594.assembly.stream.el8
**Pullspec**: registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-operator-sdk@sha256:99e4e4b5f6a1918c09ac909b200f5547f62be9d5e52400e60097d7cce5b843d0
**Dockerfile**: https://github.com/openshift/ocp-release-operator-sdk/blob/release-4.11/release/sdk/Dockerfile