### PR TITLE
[4.15] exclude sriov-cni-container ErrLibcryptoSoMissing

### DIFF
--- a/dist/releases/4.15/config.toml
+++ b/dist/releases/4.15/config.toml
@@ -89,3 +89,7 @@ files = ["/usr/lib/golang/pkg/tool/linux_amd64/cgo"]
 [[payload.openshift-enterprise-operator-sdk-container.ignore]]
 error = "ErrLibcryptoMissing"
 files = ["/usr/lib/golang/pkg/tool/linux_amd64/cgo"]
+
+[[payload.sriov-cni-container.ignore]]
+error = "ErrLibcryptoSoMissing"
+files = ["/usr/bin/rhel8/sriov"]


### PR DESCRIPTION
Dockerfile: https://github.com/openshift/sriov-cni/blob/release-4.15/Dockerfile.rhel
Slack [thread](https://redhat-internal.slack.com/archives/CB95J6R4N/p1715889366059319)