### PR TITLE
Fix braces

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -109,12 +109,6 @@ files = ["/usr/lib/dracut/modules.d/30ignition/ignition"]
 error = "ErrNotDynLinked"
 files = ["/usr/bin/pod"]
 
-[payload.operator-lifecycle-manager-container]
-filter_files = ["/usr/bin/cpb", "/usr/bin/copy-content"]
-
-[payload.ose-olm-rukpak-container]
-filter_files = ["/unpack"]
-
 [[payload.openshift-virtualization-virt-container.ignore]]
 error = "ErrNotDynLinked"
 files = ["/usr/bin/container-disk"]


### PR DESCRIPTION
The single "[" resulted in ignoring the following lines in the
config file.

In addition, payload.operator-lifecycle-manager-container and
payload.ose-olm-rukpak-container are missing the error to
mask.