### PR TITLE
Add skopeo and umoci to CI image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,18 @@ RUN make
 
 FROM registry.ci.openshift.org/ocp/4.14:base-rhel9
 ARG OC_VERSION=latest
-RUN dnf -y update && dnf install -y binutils file go podman runc jq && dnf clean all
+ARG UMOCI_VERSION=latest
+
+RUN dnf -y update && dnf install -y binutils file go podman runc jq skopeo && dnf clean all
 RUN wget -O "openshift-client-linux-${OC_VERSION}.tar.gz" "https://mirror.openshift.com/pub/openshift-v4/amd64/clients/ocp/${OC_VERSION}/openshift-client-linux.tar.gz" \
   && tar -C /usr/local/bin -xzvf "openshift-client-linux-$OC_VERSION.tar.gz" oc
 RUN curl --fail --retry 3 -LJO https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest-4.14/opm-linux.tar.gz && \
     tar -xzf opm-linux.tar.gz && \
     mv ./opm /usr/local/bin/ && \
     rm -f opm-linux.tar.gz
+RUN wget -O /usr/local/bin/umoci "https://github.com/opencontainers/umoci/releases/$UMOCI_VERSION/download/umoci.amd64" && \
+    chmod +x /usr/local/bin/umoci
+
 COPY --from=builder /app/check-payload /check-payload
 
 ENTRYPOINT ["/check-payload"]

--- a/Dockerfile.upstream
+++ b/Dockerfile.upstream
@@ -9,14 +9,18 @@ RUN make
 
 FROM fedora:38
 ARG OC_VERSION=latest
+ARG UMOCI_VERSION=latest
 
 RUN curl -LJo "openshift-client-linux-${OC_VERSION}.tar.gz" "https://mirror.openshift.com/pub/openshift-v4/amd64/clients/ocp/${OC_VERSION}/openshift-client-linux.tar.gz" \
   && tar -C /usr/local/bin -xzvf "openshift-client-linux-$OC_VERSION.tar.gz" oc
-RUN dnf -y update && dnf install -y binutils go file runc podman jq && dnf clean all
+RUN dnf -y update && dnf install -y binutils go file runc podman jq skopeo && dnf clean all
 RUN curl --fail --retry 3 -LJO https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest-4.14/opm-linux.tar.gz && \
     tar -xzf opm-linux.tar.gz && \
     mv ./opm /usr/local/bin/ && \
     rm -f opm-linux.tar.gz
+RUN wget -O /usr/local/bin/umoci "https://github.com/opencontainers/umoci/releases/download/$UMOCI_VERSION/umoci.amd64" && \
+    chmod +x /usr/local/bin/umoci
+
 COPY --from=builder /app/check-payload /check-payload
 
 ENTRYPOINT ["/check-payload"]


### PR DESCRIPTION
Adds skopeo and umoci binaries to the check-payload image (useful when using `scan local`).

xref: https://redhat-internal.slack.com/archives/C05U13J3LLS/p1716476010936559?thread_ts=1715954957.336589&cid=C05U13J3LLS