### PR TITLE
int/types: rm NewDefaultConfig

### DIFF
--- a/internal/scan/scan_test.go
+++ b/internal/scan/scan_test.go
@@ -3,6 +3,7 @@ package scan
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/openshift/check-payload/internal/types"
 )
@@ -19,6 +20,17 @@ func TestRunLocalScan(t *testing.T) {
 		{"BadMockUnpackedDir", "../../test/resources/mock_unpacked_dir-2", false},
 	}
 
+	cfg := &types.Config{
+		OutputFormat: "table",          // or another suitable format
+		Parallelism:  1,                // for test simplicity, you might want to run sequentially
+		TimeLimit:    30 * time.Second, // or a suitable duration
+		Verbose:      true,             // if you want verbose output during testing
+		ConfigFile: types.ConfigFile{
+			PayloadIgnores: make(map[string]types.IgnoreLists),
+			TagIgnores:     make(map[string]types.IgnoreLists),
+			RPMIgnores:     make(map[string]types.IgnoreLists),
+		},
+	}
 	// Iterate over test cases
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -26,11 +38,8 @@ func TestRunLocalScan(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			var cfg types.Config
-			cfg.NewDefaultConfig() // Assuming a method to set up default config
-
-			// Run the local scan
-			results := RunLocalScan(ctx, &cfg, tc.mockUnpackedDirPath)
+			// Run the local scan.
+			results := RunLocalScan(ctx, cfg, tc.mockUnpackedDirPath)
 
 			// Check if results meet expected criteria
 			passed := !IsFailed(results)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -131,36 +131,3 @@ func (ve *ValidationError) IsError() bool {
 func (ve *ValidationError) IsWarning() bool {
 	return ve.Level == Warning
 }
-
-// NewDefaultConfig initializes the configuration with default values for testing.
-func (c *Config) NewDefaultConfig() {
-	// Set default values for testing
-	c.Components = []string{} // or any default components
-	c.FailOnWarnings = false  // depending on your test cases
-	c.FilterFile = ""
-	c.FromFile = ""
-	c.FromURL = ""
-	c.InsecurePull = false
-	c.Limit = -1 // or a suitable default
-	c.ContainerImageComponent = ""
-	c.ContainerImage = ""
-	c.OutputFile = ""
-	c.OutputFormat = "table" // or another suitable format
-	c.Parallelism = 1        // for test simplicity, you might want to run sequentially
-	c.Java = false
-	c.PrintExceptions = false
-	c.PullSecret = ""
-	c.TimeLimit = 30 * time.Second // or a suitable duration
-	c.Verbose = true               // if you want verbose output during testing
-	c.UseRPMScan = false
-
-	// also set up default values for the ConfigFile part of Config if needed
-	c.FilterFiles = []string{}
-	c.FilterDirs = []string{}
-	c.FilterImages = []string{}
-	c.JavaDisabledAlgorithms = []string{}
-	c.PayloadIgnores = make(map[string]IgnoreLists)
-	c.TagIgnores = make(map[string]IgnoreLists)
-	c.RPMIgnores = make(map[string]IgnoreLists)
-	c.ErrIgnores = []ErrIgnore{}
-}


### PR DESCRIPTION
The `NewDefaultConfig` method has a few issues:
 - its name is misleading (it does not create a new object);
 - it is only used in tests (and thus do not belong to non-test codebase);
 - it has quite a few inits that are redundant.

 Remove it, and add a simple init right to the test case. We can move it
 out to a separate function in test later if need arises.