### PR TITLE
Fix golang 1.22 symbols check

### DIFF
--- a/internal/validations/validations.go
+++ b/internal/validations/validations.go
@@ -83,9 +83,9 @@ func validateGoSymbols(_ context.Context, path string, baton *Baton) *types.Vali
 		return nil
 	}
 
-	requiredGolangSymbols := requiredGolangSymbolsPre122
+	requiredGolangSymbols := requiredGolangSymbolsPost122
 	if goLessThan122.Check(baton.GoVersion) {
-		requiredGolangSymbols = requiredGolangSymbolsPost122
+		requiredGolangSymbols = requiredGolangSymbolsPre122
 	}
 	if goLessThan118.Check(baton.GoVersion) {
 		return nil


### PR DESCRIPTION
Original PR[1] added the go 1.22 version check wrongly, this patch fixes it.

[1] https://github.com/openshift/check-payload/pull/196

Related-Issue: [CMP-2633](https://issues.redhat.com//browse/CMP-2633)
Related-Issue: [OSPCIX-338](https://issues.redhat.com//browse/OSPCIX-338)