### PR TITLE
exclude operator-lifecycle-manager-container

### DIFF
--- a/dist/releases/4.12/config.toml
+++ b/dist/releases/4.12/config.toml
@@ -9,3 +9,31 @@ files = ["/usr/lib/golang/pkg/tool/linux_amd64/cgo"]
 [[payload.openshift-enterprise-operator-sdk-container.ignore]]
 error = "ErrLibcryptoMissing"
 files = ["/usr/lib/golang/pkg/tool/linux_amd64/cgo"]
+
+[[payload.operator-lifecycle-manager-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/cpb", "/usr/bin/copy-content"]
+
+[[payload.operator-lifecycle-manager-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/bin/cpb", "/usr/bin/copy-content"]
+
+[[payload.operator-lifecycle-manager-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/bin/cpb", "/usr/bin/copy-content"]
+
+[[payload.operator-lifecycle-manager-container.ignore]]
+error = "ErrGoMissingTag"
+files = ["/usr/bin/cpb", "/usr/bin/copy-content"]
+
+[[payload.operator-lifecycle-manager-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/usr/bin/cpb", "/usr/bin/copy-content"]
+
+[[payload.operator-lifecycle-manager-container.ignore]]
+error = "ErrLibcryptoSoMissing"
+files = ["/usr/bin/cpb"]
+
+[[payload.operator-lifecycle-manager-container.ignore]]
+error = "ErrLibcryptoMissing"
+files = ["/usr/bin/cpb"]


### PR DESCRIPTION
Dockerfile: https://github.com/openshift/operator-framework-olm/blob/release-4.12/operator-lifecycle-manager.Dockerfile

Failed nightly [run](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.12-fips-payload-scan/1804169324097703936)

Coping over from from 4.13 exclude