### PR TITLE
set info.Certified as false, if empty string

### DIFF
--- a/internal/validations/validations_os.go
+++ b/internal/validations/validations_os.go
@@ -22,8 +22,9 @@ func ValidateOS(cfg *types.Config, mountPath string) (info types.OSInfo) {
 	}
 
 	for _, d := range cd {
-	    cd_bytes = []byte(d)
-		if f != "" && cd_bytes != "" && bytes.HasPrefix(f, cd_bytes) {
+	    cd_bytes := []byte(d)
+
+		if len(f) != 0 && len(cd_bytes) != 0 && bytes.HasPrefix(f, cd_bytes) {
 			info.Certified = true
 			break
 		}

--- a/internal/validations/validations_os.go
+++ b/internal/validations/validations_os.go
@@ -22,7 +22,8 @@ func ValidateOS(cfg *types.Config, mountPath string) (info types.OSInfo) {
 	}
 
 	for _, d := range cd {
-		if bytes.HasPrefix(f, []byte(d)) {
+	    cd_bytes = []byte(d)
+		if f != "" && cd_bytes != "" && bytes.HasPrefix(f, cd_bytes) {
 			info.Certified = true
 			break
 		}


### PR DESCRIPTION
Follows https://github.com/openshift/check-payload/pull/175

`openshift-enterprise-pod-container` was passing scan if `-V 4.16` was set, even though it was not mentioned in the [excludes](https://github.com/openshift/check-payload/blob/main/dist/releases/4.16/config.toml) 

thead [here](https://redhat-internal.slack.com/archives/CB95J6R4N/p1719324150710139?thread_ts=1719309951.266479&amp;cid=CB95J6R4N)