### PR TITLE
[OSSM-6411] Ignore rhel9 binary in rhel8 istio-cni image

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -116,3 +116,7 @@ files = ["/usr/bin/container-disk"]
 [[payload.openshift-virtualization-cdi-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.openshift-istio-cni-rhel8-container.ignore]]
+error = "ErrLibcryptoSoMissing"
+files = ["/opt/cni/bin/istio-cni-rhel9"]


### PR DESCRIPTION
We are building a rhel8-based image that includes both rhel8 and rhel9 cni binary and copies the correct one to the node at runtime. See https://issues.redhat.com/browse/OSSM-6411 for details