### PR TITLE
CMP-2639: Exclude binary libcrypto check using golang 1.22

### DIFF
--- a/internal/validations/validations.go
+++ b/internal/validations/validations.go
@@ -38,8 +38,9 @@ var (
 		"vendor/github.com/golang-fips/openssl/v2.dlopen",
 	}
 
-	goLessThan118 = newSemverConstraint("< 1.18")
-	goLessThan122 = newSemverConstraint("< 1.22")
+	goLessThan118             = newSemverConstraint("< 1.18")
+	goLessThan122             = newSemverConstraint("< 1.22")
+	goGreaterThanOrEqualTo122 = newSemverConstraint(">= 1.22")
 
 	// correlates to java 1.8
 	JavaClassLessThan52 = newSemverConstraint("< 52")
@@ -185,6 +186,8 @@ func validateGoStatic(ctx context.Context, path string, baton *Baton) *types.Val
 func validateGoOpenssl(_ context.Context, path string, baton *Baton) *types.ValidationError {
 	// if there is no crypto then skip openssl test
 	if baton.GoNoCrypto {
+		return nil
+	} else if goGreaterThanOrEqualTo122.Check(baton.GoVersion) {
 		return nil
 	}
 	// check for openssl strings


### PR DESCRIPTION
Golang version 1.22 does not have hardcoded libcrypto versions anymore, and does not emit the libcrypto version in the binary output of a go binary (e.g., using strings).

Because of this, the approach we were using to detect the OpenSSL version based on a regular expression and attempting to match that with the binary output does not work for binaries built with golang 1.22.

This is particularly prevalent with OpenShift 4.17 payloads that are using RHEL 9 and golang 1.22 base images.

This commit updates the binary scan logic to skip checking binaries for OpenSSL versions when using golang 1.22.