### PR TITLE
config: exclude runc

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -67,6 +67,11 @@ files = ["/usr/sbin/ldconfig", "/sbin/ldconfig"]
 error = "ErrGoMissingTag"
 files = ["/usr/bin/runc"]
 
+[[rpm.runc.ignore]]
+# See OCPBUGS-36541.
+error = "ErrGoMissingSymbols"
+files = ["/usr/bin/runc"]
+
 [[rpm.podman.ignore]]
 error = "ErrGoMissingTag"
 files = [


### PR DESCRIPTION
runc does not use any cryptography, and since runc init is executed in the context of a container, trying to load openssl breaks it, so we compile runc with no_openssl tag (see OCPBUGS-36541).

Add an appropriate exclusion for runc.