### PR TITLE
add ose-operator-framework-tools-container to 4.16 exclude

### DIFF
--- a/dist/releases/4.16/config.toml
+++ b/dist/releases/4.16/config.toml
@@ -425,3 +425,7 @@ files = ["/usr/bin/cpb"]
 [[payload.ose-olm-rukpak-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = ["/unpack"]
+
+[[payload.ose-operator-framework-tools-container.ignore]]
+error = "ErrLibcryptoSoMissing"
+files = ["/tools/opm-rhel8"]


### PR DESCRIPTION
Dockerfile: https://github.com/openshift/operator-framework-olm/blob/release-4.16/operator-framework-tools.Dockerfile

Error log: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.16-fips-payload-scan/1816057374515924992