### PR TITLE
MCO: ignore additional binaries for 4.14/4.15

### DIFF
--- a/dist/releases/4.14/config.toml
+++ b/dist/releases/4.14/config.toml
@@ -8,7 +8,12 @@ files = ["/usr/bin/ovnkube-trace"]
 
 [[payload.ose-machine-config-operator-container.ignore]]
 error = "ErrLibcryptoSoMissing"
-files = ["/usr/bin/machine-config-daemon.rhel9"]
+files = [
+  "/usr/bin/machine-config-daemon.rhel9",
+  "/usr/bin/machine-config-controller.rhel9",
+  "/usr/bin/machine-config-operator.rhel9",
+  "/usr/bin/machine-config-server.rhel9",
+]
 
 [[payload.ose-node-container.ignore]]
 error = "ErrLibcryptoSoMissing"

--- a/dist/releases/4.15/config.toml
+++ b/dist/releases/4.15/config.toml
@@ -8,7 +8,12 @@ files = ["/usr/bin/ovnkube-trace"]
 
 [[payload.ose-machine-config-operator-container.ignore]]
 error = "ErrLibcryptoSoMissing"
-files = ["/usr/bin/machine-config-daemon.rhel9"]
+files = [
+  "/usr/bin/machine-config-daemon.rhel9",
+  "/usr/bin/machine-config-controller.rhel9",
+  "/usr/bin/machine-config-operator.rhel9",
+  "/usr/bin/machine-config-server.rhel9",
+]
 
 [[payload.ose-node-container.ignore]]
 error = "ErrLibcryptoSoMissing"


### PR DESCRIPTION
https://github.com/openshift/machine-config-operator/pull/4476 was needed for Hypershift to use rhel9 binaries to generate config for 4.14/4.15, so ignore them like the daemon for the dual build.

This shouldn't affect any other versions.