### PR TITLE
OCPBUGS-37846: rpm.runc ignore ErrLibcryptoMissing

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -76,6 +76,11 @@ files = ["/usr/bin/runc"]
 error = "ErrGoMissingSymbols"
 files = ["/usr/bin/runc"]
 
+[[rpm.runc.ignore]]
+# See OCPBUGS-36541.
+error = "ErrLibcryptoMissing"
+files = ["/usr/bin/runc"]
+
 [[rpm.podman.ignore]]
 error = "ErrGoMissingTag"
 files = [


### PR DESCRIPTION
The change to not link against openssl was backported to 4.16-4.12
as part of OCPBUGS-36541 but seems to manifest with different error
there than in 4.17 due to differences in golang versions.