### PR TITLE
openshift-enterprise-operator-sdk-container update exclude

### DIFF
--- a/dist/releases/4.17/config.toml
+++ b/dist/releases/4.17/config.toml
@@ -362,15 +362,27 @@ files = ["/usr/bin/rhel8/ib-sriov"]
 
 [[payload.openshift-enterprise-operator-sdk-container.ignore]]
 error = "ErrGoMissingSymbols"
-files = ["/usr/lib/golang/pkg/tool/linux_amd64/compile"]
+files = [
+  "/usr/lib/golang/pkg/tool/linux_amd64/compile",
+  "/usr/lib/golang/pkg/tool/linux_amd64/covdata",
+  "/usr/lib/golang/pkg/tool/linux_amd64/cover"
+]
 
 [[payload.openshift-enterprise-operator-sdk-container.ignore]]
 error = "ErrNotDynLinked"
-files = ["/usr/lib/golang/pkg/tool/linux_amd64/compile"]
+files = [
+  "/usr/lib/golang/pkg/tool/linux_amd64/compile",
+  "/usr/lib/golang/pkg/tool/linux_amd64/covdata",
+  "/usr/lib/golang/pkg/tool/linux_amd64/cover"
+]
 
 [[payload.openshift-enterprise-operator-sdk-container.ignore]]
 error = "ErrLibcryptoMissing"
-files = ["/usr/lib/golang/pkg/tool/linux_amd64/compile"]
+files = [
+  "/usr/lib/golang/pkg/tool/linux_amd64/compile",
+  "/usr/lib/golang/pkg/tool/linux_amd64/covdata",
+  "/usr/lib/golang/pkg/tool/linux_amd64/cover"
+]
 
 [[payload.ose-cloud-credential-operator-container.ignore]]
 error = "ErrLibcryptoSoMissing"

--- a/dist/releases/4.18/config.toml
+++ b/dist/releases/4.18/config.toml
@@ -362,15 +362,27 @@ files = ["/usr/bin/rhel8/ib-sriov"]
 
 [[payload.openshift-enterprise-operator-sdk-container.ignore]]
 error = "ErrGoMissingSymbols"
-files = ["/usr/lib/golang/pkg/tool/linux_amd64/compile"]
+files = [
+  "/usr/lib/golang/pkg/tool/linux_amd64/compile",
+  "/usr/lib/golang/pkg/tool/linux_amd64/covdata",
+  "/usr/lib/golang/pkg/tool/linux_amd64/cover"
+]
 
 [[payload.openshift-enterprise-operator-sdk-container.ignore]]
 error = "ErrNotDynLinked"
-files = ["/usr/lib/golang/pkg/tool/linux_amd64/compile"]
+files = [
+  "/usr/lib/golang/pkg/tool/linux_amd64/compile",
+  "/usr/lib/golang/pkg/tool/linux_amd64/covdata",
+  "/usr/lib/golang/pkg/tool/linux_amd64/cover"
+]
 
 [[payload.openshift-enterprise-operator-sdk-container.ignore]]
 error = "ErrLibcryptoMissing"
-files = ["/usr/lib/golang/pkg/tool/linux_amd64/compile"]
+files = [
+  "/usr/lib/golang/pkg/tool/linux_amd64/compile",
+  "/usr/lib/golang/pkg/tool/linux_amd64/covdata",
+  "/usr/lib/golang/pkg/tool/linux_amd64/cover"
+]
 
 [[payload.ose-cloud-credential-operator-container.ignore]]
 error = "ErrLibcryptoSoMissing"


### PR DESCRIPTION
Follows https://github.com/openshift/check-payload/pull/213

Dockerfile: https://github.com/openshift/ocp-release-operator-sdk/blob/release-4.17/release/sdk/Dockerfile

In the initial Slack [thread](https://redhat-internal.slack.com/archives/CB95J6R4N/p1723054496104479) we only saw failures in 4.13-4.15, but now it seems to be failing in 4.17 and 4.18 as well. 

No issues reported in 4.16 though, not sure why.

