### PR TITLE
multicluster-operators-subscription-operator-container excludes for ACM

### DIFF
--- a/dist/releases/4.12/config.toml
+++ b/dist/releases/4.12/config.toml
@@ -37,3 +37,7 @@ files = ["/usr/bin/cpb"]
 [[payload.operator-lifecycle-manager-container.ignore]]
 error = "ErrLibcryptoMissing"
 files = ["/usr/bin/cpb"]
+
+[[payload.multicluster-operators-subscription-operator-container.ignore]]
+error = "ErrLibcryptoSoMissing"
+files = ["/policy-generator/PolicyGenerator-rhel8"]

--- a/dist/releases/4.13/config.toml
+++ b/dist/releases/4.13/config.toml
@@ -93,3 +93,7 @@ files = ["/usr/bin/cpb"]
 [[payload.operator-lifecycle-manager-container.ignore]]
 error = "ErrLibcryptoMissing"
 files = ["/usr/bin/cpb"]
+
+[[payload.multicluster-operators-subscription-operator-container.ignore]]
+error = "ErrLibcryptoSoMissing"
+files = ["/policy-generator/PolicyGenerator-rhel8"]

--- a/dist/releases/4.14/config.toml
+++ b/dist/releases/4.14/config.toml
@@ -114,3 +114,7 @@ files = ["/usr/bin/cpb"]
 [[payload.ose-olm-rukpak-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = ["/unpack"]
+
+[[payload.multicluster-operators-subscription-operator-container.ignore]]
+error = "ErrLibcryptoSoMissing"
+files = ["/policy-generator/PolicyGenerator-rhel8"]

--- a/dist/releases/4.15/config.toml
+++ b/dist/releases/4.15/config.toml
@@ -145,3 +145,7 @@ files = ["/usr/bin/cpb"]
 [[payload.ose-olm-rukpak-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = ["/unpack"]
+
+[[payload.multicluster-operators-subscription-operator-container.ignore]]
+error = "ErrLibcryptoSoMissing"
+files = ["/policy-generator/PolicyGenerator-rhel8"]

--- a/dist/releases/4.16/config.toml
+++ b/dist/releases/4.16/config.toml
@@ -429,3 +429,7 @@ files = ["/unpack"]
 [[payload.ose-operator-framework-tools-container.ignore]]
 error = "ErrLibcryptoSoMissing"
 files = ["/tools/opm-rhel8"]
+
+[[payload.multicluster-operators-subscription-operator-container.ignore]]
+error = "ErrLibcryptoSoMissing"
+files = ["/policy-generator/PolicyGenerator-rhel8"]

--- a/dist/releases/4.17/config.toml
+++ b/dist/releases/4.17/config.toml
@@ -431,3 +431,7 @@ files = ["/usr/bin/cpb"]
 [[payload.ose-olm-rukpak-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = ["/unpack"]
+
+[[payload.multicluster-operators-subscription-operator-container.ignore]]
+error = "ErrLibcryptoSoMissing"
+files = ["/policy-generator/PolicyGenerator-rhel8"]

--- a/dist/releases/4.18/config.toml
+++ b/dist/releases/4.18/config.toml
@@ -431,3 +431,7 @@ files = ["/usr/bin/cpb"]
 [[payload.ose-olm-rukpak-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = ["/unpack"]
+
+[[payload.multicluster-operators-subscription-operator-container.ignore]]
+error = "ErrLibcryptoSoMissing"
+files = ["/policy-generator/PolicyGenerator-rhel8"]


### PR DESCRIPTION
ACM 2.12 build has a check-payload failure for an extra binary we include compiled on rhel8. Error link:
https://jenkins-cvp-5e54f0365a134668768b8f38.apps.ocp-c1.prod.psi.redhat.com/job/cvp-redhat-operator-bundle-image-validation-test/400/artifact/operator-fips-static-check-bundle-image-output.txt