### PR TITLE
CMP-2734: Detect usage of x/crypto

### DIFF
--- a/internal/types/error_map.go
+++ b/internal/types/error_map.go
@@ -4,6 +4,7 @@ package types
 
 var KnownErrors = map[string]error {
 	"ErrCertifiedDistributionsEmpty": ErrCertifiedDistributionsEmpty,
+	"ErrDetectedExcludedModule": ErrDetectedExcludedModule,
 	"ErrDistributionFileMissing": ErrDistributionFileMissing,
 	"ErrGoInvalidTag": ErrGoInvalidTag,
 	"ErrGoMissingSymbols": ErrGoMissingSymbols,

--- a/internal/types/errors.go
+++ b/internal/types/errors.go
@@ -21,4 +21,5 @@ var (
 	ErrOSNotCertified              = errors.New("operating system is not FIPS certified")
 	ErrDistributionFileMissing     = errors.New("could not find distribution file")
 	ErrCertifiedDistributionsEmpty = errors.New("certified_distributions is empty, consider using -V [VERSION] for check-payload")
+	ErrDetectedExcludedModule      = errors.New("detected a library that is incompatible with FIPS, check to make sure it is not performing any cryptographic operations")
 )


### PR DESCRIPTION
The x/crypto module isn't compatible with FIPS. Let's write a check to
see if it is in the symbols for a given binary. Ideally, this should
help us find areas where we can remove x/crypto usage altogether.
