### PR TITLE
CMP-2853: Exclude QE convenience containers

### DIFF
--- a/dist/releases/4.17/config.toml
+++ b/dist/releases/4.17/config.toml
@@ -431,3 +431,9 @@ files = ["/usr/bin/cpb"]
 [[payload.ose-olm-rukpak-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = ["/unpack"]
+
+# These binaries are not built with CGO enabled because they're convenience
+# containers for QE testing.
+[[payload.multicluster-engine-hypershift-operator-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]


### PR DESCRIPTION
These containers aren't built with CGO enabled, but they're not used as
part of the MCE operator. They're just shipped with the operator as a
convenience so QE can extract them and use them for testing.
