### PR TITLE
int/rpm: use abs path for rpm --root

### DIFF
--- a/internal/rpm/rpm.go
+++ b/internal/rpm/rpm.go
@@ -42,6 +42,10 @@ func GetFilesFromRPM(ctx context.Context, root, rpm string) ([]string, error) {
 
 func GetAllRPMs(ctx context.Context, root string) ([]Info, error) {
 	klog.Info("rpm -qa")
+	root, err := filepath.Abs(root)
+	if err != nil {
+		return nil, err
+	}
 	dbpath, err := rpmDBPath(root)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When performing a local scan, a relative path can be provided, and rpm fails like this:

	rpm -qf error: exit status 1 (stderr=rpm: arguments to --root (-r) must begin with a /)

Use an absolute path.