### PR TITLE
Add RHEL 9.4 to certified distributions

### DIFF
--- a/dist/releases/4.16/config.toml
+++ b/dist/releases/4.16/config.toml
@@ -1,4 +1,7 @@
-certified_distributions = [ "Red Hat Enterprise Linux release 9.2 (Plow)" ]
+certified_distributions = [
+  "Red Hat Enterprise Linux release 9.2 (Plow)",
+  "Red Hat Enterprise Linux release 9.4 (Plow)",
+]
 
 [[payload.ubi9-container.ignore]]
 error = "ErrOSNotCertified"


### PR DESCRIPTION
RHEL 9.2 and 9.4 share openssl fips providers and thus should be equivalent