### PR TITLE
Update checks to support golang 1.21.13 symbols

### DIFF
--- a/internal/validations/validations.go
+++ b/internal/validations/validations.go
@@ -27,11 +27,14 @@ var (
 	// Compile regular expressions once during initialization.
 	validateStringsOpensslRegexp = regexp.MustCompile(`libcrypto.so(\.?\d+)*`)
 
-	// Use these symbols for all go versions up to 1.22. These symbols
-	// changed in version 1.22, so we can't use them if we're dealing with
-	// 1.22 or greater.
-	requiredGolangSymbolsPre122 = []string{
+	// Use these symbols for all go versions up to 1.21.13. These symbols
+	// changed in version 1.21.13 and again in 1.22
+	requiredGolangSymbolsPre12113 = []string{
 		"vendor/github.com/golang-fips/openssl-fips/openssl._Cfunc__goboringcrypto_DLOPEN_OPENSSL",
+		"crypto/internal/boring._Cfunc__goboringcrypto_DLOPEN_OPENSSL",
+	}
+	requiredGolangSymbolsPre122 = []string{
+		"vendor/github.com/golang-fips/openssl/openssl._Cfunc__goboringcrypto_DLOPEN_OPENSSL",
 		"crypto/internal/boring._Cfunc__goboringcrypto_DLOPEN_OPENSSL",
 	}
 	requiredGolangSymbolsPost122 = []string{
@@ -39,6 +42,7 @@ var (
 	}
 
 	goLessThan118             = newSemverConstraint("< 1.18")
+	goLessThan12113           = newSemverConstraint("< 1.21.13")
 	goLessThan122             = newSemverConstraint("< 1.22")
 	goGreaterThanOrEqualTo122 = newSemverConstraint(">= 1.22")
 
@@ -85,11 +89,12 @@ func validateGoSymbols(_ context.Context, path string, baton *Baton) *types.Vali
 	}
 
 	requiredGolangSymbols := requiredGolangSymbolsPost122
-	if goLessThan122.Check(baton.GoVersion) {
-		requiredGolangSymbols = requiredGolangSymbolsPre122
-	}
 	if goLessThan118.Check(baton.GoVersion) {
 		return nil
+	} else if goLessThan12113.Check(baton.GoVersion) {
+		requiredGolangSymbols = requiredGolangSymbolsPre12113
+	} else if goLessThan122.Check(baton.GoVersion) {
+		requiredGolangSymbols = requiredGolangSymbolsPre122
 	}
 	if !golang.ExpectedSyms(requiredGolangSymbols, symtable) {
 		return types.NewValidationError(types.ErrGoMissingSymbols)


### PR DESCRIPTION
Changed from `openssl-fips` to `openssl` in 
https://github.com/golang-fips/go/commit/1a6ccca3dfbb775968f7355de81d1e615b6f334f#diff-36aa6419af2cb44101da524e8049e031f55f5733b7867a0bee642e0173794269L34