### PR TITLE
OCPBUGS-43103: skip ErrNotDynLinked for catatonit in ansible-operator

### DIFF
--- a/dist/releases/4.17/config.toml
+++ b/dist/releases/4.17/config.toml
@@ -384,6 +384,10 @@ files = [
   "/usr/lib/golang/pkg/tool/linux_amd64/cover"
 ]
 
+[[payload.openshift-enterprise-ansible-operator-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/libexec/catatonit/catatonit"]
+
 [[payload.ose-cloud-credential-operator-container.ignore]]
 error = "ErrLibcryptoSoMissing"
 files = ["/usr/bin/ccoctl", "/usr/bin/ccoctl.rhel8"]

--- a/dist/releases/4.18/config.toml
+++ b/dist/releases/4.18/config.toml
@@ -384,6 +384,10 @@ files = [
   "/usr/lib/golang/pkg/tool/linux_amd64/cover"
 ]
 
+[[payload.openshift-enterprise-ansible-operator-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/libexec/catatonit/catatonit"]
+
 [[payload.ose-cloud-credential-operator-container.ignore]]
 error = "ErrLibcryptoSoMissing"
 files = ["/usr/bin/ccoctl", "/usr/bin/ccoctl.rhel8"]

--- a/dist/releases/4.19/config.toml
+++ b/dist/releases/4.19/config.toml
@@ -384,6 +384,10 @@ files = [
   "/usr/lib/golang/pkg/tool/linux_amd64/cover"
 ]
 
+[[payload.openshift-enterprise-ansible-operator-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/libexec/catatonit/catatonit"]
+
 [[payload.ose-cloud-credential-operator-container.ignore]]
 error = "ErrLibcryptoSoMissing"
 files = ["/usr/bin/ccoctl", "/usr/bin/ccoctl.rhel8"]


### PR DESCRIPTION
Skip `executable is not dynamically linked` for `/usr/libexec/catatonit/catatonit` in [ansible-operator](https://github.com/openshift/ansible-operator-plugins/blob/d31f0a93e2523a67b5589c82884cc632331876d5/openshift/Dockerfile#L57)

`catatonit` has to be a static binary, and as per [Slack discussion](https://redhat-internal.slack.com/archives/CB95J6R4N/p1729083693856789), it does not perform any cryptographic operations.

https://pkgs.devel.redhat.com/cgit/rpms/catatonit/tree/catatonit.spec?h=rhel-9-main#n36

- Added fix for 4.17+
- Part of: https://issues.redhat.com/browse/OCPBUGS-43103
