### PR TITLE
openshift-enterprise-operator-sdk-container update excludes for 4.16

### DIFF
--- a/dist/releases/4.16/config.toml
+++ b/dist/releases/4.16/config.toml
@@ -371,15 +371,30 @@ files = ["/usr/bin/rhel8/ib-sriov"]
 
 [[payload.openshift-enterprise-operator-sdk-container.ignore]]
 error = "ErrGoMissingSymbols"
-files = ["/usr/lib/golang/pkg/tool/linux_amd64/compile"]
+files = [
+  "/usr/lib/golang/pkg/tool/linux_amd64/cgo",
+  "/usr/lib/golang/pkg/tool/linux_amd64/compile",
+  "/usr/lib/golang/pkg/tool/linux_amd64/covdata",
+  "/usr/lib/golang/pkg/tool/linux_amd64/cover"
+]
 
 [[payload.openshift-enterprise-operator-sdk-container.ignore]]
 error = "ErrNotDynLinked"
-files = ["/usr/lib/golang/pkg/tool/linux_amd64/compile"]
+files = [
+  "/usr/lib/golang/pkg/tool/linux_amd64/cgo",
+  "/usr/lib/golang/pkg/tool/linux_amd64/compile",
+  "/usr/lib/golang/pkg/tool/linux_amd64/covdata",
+  "/usr/lib/golang/pkg/tool/linux_amd64/cover"
+]
 
 [[payload.openshift-enterprise-operator-sdk-container.ignore]]
 error = "ErrLibcryptoMissing"
-files = ["/usr/lib/golang/pkg/tool/linux_amd64/compile"]
+files = [
+  "/usr/lib/golang/pkg/tool/linux_amd64/cgo",
+  "/usr/lib/golang/pkg/tool/linux_amd64/compile",
+  "/usr/lib/golang/pkg/tool/linux_amd64/covdata",
+  "/usr/lib/golang/pkg/tool/linux_amd64/cover"
+]
 
 [[payload.ose-cloud-credential-operator-container.ignore]]
 error = "ErrLibcryptoSoMissing"


### PR DESCRIPTION
Follow up of #213 for 4.16. Slack ref: https://redhat-internal.slack.com/archives/CB95J6R4N/p1729089144767989?thread_ts=1729082454.815379&cid=CB95J6R4N