### PR TITLE
fixes for check-payload for 4.15

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -93,6 +93,10 @@ files = [
 error = "ErrNotDynLinked"
 files = ["/usr/libexec/podman/catatonit"]
 
+[[rpm.podman.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/libexec/podman/rootlessport"]
+
 [[rpm.podman-catatonit.ignore]]
 error = "ErrNotDynLinked"
 files = ["/usr/libexec/catatonit/catatonit"]

--- a/dist/releases/4.15/config.toml
+++ b/dist/releases/4.15/config.toml
@@ -89,7 +89,7 @@ files = [
   "/usr/lib/golang/pkg/tool/linux_amd64/cgo",
   "/usr/lib/golang/pkg/tool/linux_amd64/compile",
   "/usr/lib/golang/pkg/tool/linux_amd64/covdata",
-  "/usr/lib/golang/pkg/tool/linux_amd64/cover"
+  "/usr/lib/golang/pkg/tool/linux_amd64/cover",
 ]
 
 [[payload.openshift-enterprise-operator-sdk-container.ignore]]
@@ -98,7 +98,7 @@ files = [
   "/usr/lib/golang/pkg/tool/linux_amd64/cgo",
   "/usr/lib/golang/pkg/tool/linux_amd64/compile",
   "/usr/lib/golang/pkg/tool/linux_amd64/covdata",
-  "/usr/lib/golang/pkg/tool/linux_amd64/cover"
+  "/usr/lib/golang/pkg/tool/linux_amd64/cover",
 ]
 
 [[payload.openshift-enterprise-operator-sdk-container.ignore]]
@@ -107,7 +107,7 @@ files = [
   "/usr/lib/golang/pkg/tool/linux_amd64/cgo",
   "/usr/lib/golang/pkg/tool/linux_amd64/compile",
   "/usr/lib/golang/pkg/tool/linux_amd64/covdata",
-  "/usr/lib/golang/pkg/tool/linux_amd64/cover"
+  "/usr/lib/golang/pkg/tool/linux_amd64/cover",
 ]
 
 [[payload.sriov-cni-container.ignore]]
@@ -143,5 +143,9 @@ error = "ErrLibcryptoMissing"
 files = ["/usr/bin/cpb"]
 
 [[payload.ose-olm-rukpak-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/unpack"]
+
+[[payload.rhel-coreos.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = ["/unpack"]

--- a/internal/validations/validations.go
+++ b/internal/validations/validations.go
@@ -30,7 +30,7 @@ var (
 	// Use these symbols for all go versions up to 1.21.13. These symbols
 	// changed in version 1.21.13 and again in 1.22
 	requiredGolangSymbolsPre12113 = []string{
-		"vendor/github.com/golang-fips/openssl-fips/openssl._Cfunc__goboringcrypto_DLOPEN_OPENSSL",
+		"vendor/github.com/golang-fips/openssl/openssl._Cfunc__goboringcrypto_DLOPEN_OPENSSL",
 		"crypto/internal/boring._Cfunc__goboringcrypto_DLOPEN_OPENSSL",
 	}
 	requiredGolangSymbolsPre122 = []string{


### PR DESCRIPTION
The symbol import changed in go 1.20.12 from:
 `vendor/github.com/golang-fips/**openssl-fips**/openssl._Cfunc__goboringcrypto_DLOPEN_OPENSSL` to `vendor/github.com/golang-fips/**openssl**/openssl._Cfunc__goboringcrypto_DLOPEN_OPENSSL`