### PR TITLE
skip ErrNotDynLinked for catatonit in ansible-operator

### DIFF
--- a/dist/releases/4.16/config.toml
+++ b/dist/releases/4.16/config.toml
@@ -396,6 +396,10 @@ files = [
   "/usr/lib/golang/pkg/tool/linux_amd64/cover"
 ]
 
+[[payload.openshift-enterprise-ansible-operator-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/libexec/catatonit/catatonit"]
+
 [[payload.ose-cloud-credential-operator-container.ignore]]
 error = "ErrLibcryptoSoMissing"
 files = ["/usr/bin/ccoctl", "/usr/bin/ccoctl.rhel8"]


### PR DESCRIPTION
Same as https://github.com/openshift/check-payload/pull/223

Since We they did a [full backport](https://github.com/openshift/ansible-operator-plugins/pull/25#issuecomment-2473496072) from 4.17 to 4.16 for ansible image to support RHEL9

ref slack [thread](https://redhat-internal.slack.com/archives/CB95J6R4N/p1734448924031899?thread_ts=1729083693.856789&cid=CB95J6R4N)