### PR TITLE
Cnv fips separate the package files to pass the scan

### DIFF
--- a/dist/releases/4.13/config.toml
+++ b/dist/releases/4.13/config.toml
@@ -94,8 +94,21 @@ files = ["/usr/bin/cpb"]
 error = "ErrLibcryptoMissing"
 files = ["/usr/bin/cpb"]
 
+[[payload.multicluster-engine-hypershift-operator-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/hcp-no-cgo"]
+
+[[payload.multicluster-engine-hypershift-operator-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/hypershift-no-cgo"]
+
 
 [[payload.hco-bundle-registry-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/bin/container-disk"]
+
+
+[[payload.virt-handler-rhel9-container.ignore]]
 error = "ErrNotDynLinked"
 files = ["/usr/bin/container-disk"]
 
@@ -106,48 +119,48 @@ files = ["/usr/bin/container-disk"]
 [[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-  "/usr/bin/cdi-containerimage-server"
+"/usr/bin/cdi-containerimage-server"
 ]
 
 [[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-  "/usr/bin/kubevirt-tekton-tasks.test"
+"/usr/bin/kubevirt-tekton-tasks.test"
 ]
 
 [[payload.kubevirt-ssp-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-  "/usr/bin/ssp-operator.test"
+"/usr/bin/ssp-operator.test"
 ]
 
 [[payload.kubevirt-tekton-tasks-copy-template-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-  "/usr/bin/kubevirt-tekton-tasks.test"
+"/usr/bin/kubevirt-tekton-tasks.test"
 ]
 
 [[payload.kubevirt-tekton-tasks-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-  "/usr/bin/tekton-tasks-operator.test"
+"/usr/bin/tekton-tasks-operator.test"
 ]
 
 [[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-  "/usr/local/bin/disk-uploader",
-  "/usr/local/bin/kubevirt-tekton-tasks.test"
+"/usr/local/bin/disk-uploader",
+"/usr/local/bin/kubevirt-tekton-tasks.test"
 ]
 
 [[payload.kubevirt-ssp-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-  "/usr/bin/ssp-operator.test"
+"/usr/bin/ssp-operator.test"
 ]
 
 [[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-  "/usr/bin/tekton-tasks-operator.test"
+"/usr/bin/tekton-tasks-operator.test"
 ]

--- a/dist/releases/4.13/config.toml
+++ b/dist/releases/4.13/config.toml
@@ -96,11 +96,7 @@ files = ["/usr/bin/cpb"]
 
 [[payload.multicluster-engine-hypershift-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = ["/usr/bin/hcp-no-cgo"]
-
-[[payload.multicluster-engine-hypershift-operator-container.ignore]]
-error = "ErrGoNotCgoEnabled"
-files = ["/usr/bin/hypershift-no-cgo"]
+files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
 
 
 [[payload.hco-bundle-registry-container.ignore]]

--- a/dist/releases/4.13/config.toml
+++ b/dist/releases/4.13/config.toml
@@ -94,16 +94,59 @@ files = ["/usr/bin/cpb"]
 error = "ErrLibcryptoMissing"
 files = ["/usr/bin/cpb"]
 
-[[payload.hco-bundle-registry-container.ignore]]
+[[payload.virt-handler-rhel9-container.ignore]]
 error = "ErrNotDynLinked"
 files = ["/usr/bin/container-disk"]
 
-[[payload.hco-bundle-registry-container.ignore]]
+[[payload.virt-launcher-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/bin/container-disk"]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-  "/usr/bin/cdi-containerimage-server",
+  "/usr/bin/cdi-containerimage-server"
+]
+
+[[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-ssp-operator-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/ssp-operator.test"
+]
+
+[[payload.kubevirt-tekton-tasks-copy-template-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-tekton-tasks-operator-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/tekton-tasks-operator.test"
+]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
   "/usr/local/bin/disk-uploader",
-  "/usr/local/bin/kubevirt-tekton-tasks.test",
-  "/usr/bin/ssp-operator.test",
+  "/usr/local/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-ssp-operator-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/ssp-operator.test"
+]
+
+[[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
   "/usr/bin/tekton-tasks-operator.test"
 ]

--- a/dist/releases/4.18/config.toml
+++ b/dist/releases/4.18/config.toml
@@ -438,12 +438,7 @@ files = ["/unpack"]
 
 [[payload.multicluster-engine-hypershift-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = ["/usr/bin/hcp-no-cgo"]
-
-[[payload.multicluster-engine-hypershift-operator-container.ignore]]
-error = "ErrGoNotCgoEnabled"
-files = ["/usr/bin/hypershift-no-cgo"]
-
+files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
 
 [[payload.hco-bundle-registry-container.ignore]]
 error = "ErrNotDynLinked"

--- a/dist/releases/4.18/config.toml
+++ b/dist/releases/4.18/config.toml
@@ -436,6 +436,19 @@ files = ["/usr/bin/cpb"]
 error = "ErrGoNotCgoEnabled"
 files = ["/unpack"]
 
+[[payload.multicluster-engine-hypershift-operator-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/hcp-no-cgo"]
+
+[[payload.multicluster-engine-hypershift-operator-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/hypershift-no-cgo"]
+
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/bin/container-disk"]
+
 [[payload.hco-bundle-registry-container.ignore]]
 error = "ErrNotDynLinked"
 files = ["/usr/bin/container-disk"]

--- a/dist/releases/4.18/config.toml
+++ b/dist/releases/4.18/config.toml
@@ -436,16 +436,59 @@ files = ["/usr/bin/cpb"]
 error = "ErrGoNotCgoEnabled"
 files = ["/unpack"]
 
-[[payload.hco-bundle-registry-container.ignore]]
+[[payload.virt-handler-rhel9-container.ignore]]
 error = "ErrNotDynLinked"
 files = ["/usr/bin/container-disk"]
 
-[[payload.hco-bundle-registry-container.ignore]]
+[[payload.virt-launcher-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/bin/container-disk"]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-  "/usr/bin/cdi-containerimage-server",
+  "/usr/bin/cdi-containerimage-server"
+]
+
+[[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-ssp-operator-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/ssp-operator.test"
+]
+
+[[payload.kubevirt-tekton-tasks-copy-template-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-tekton-tasks-operator-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/tekton-tasks-operator.test"
+]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
   "/usr/local/bin/disk-uploader",
-  "/usr/local/bin/kubevirt-tekton-tasks.test",
-  "/usr/bin/ssp-operator.test",
+  "/usr/local/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-ssp-operator-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/ssp-operator.test"
+]
+
+[[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
   "/usr/bin/tekton-tasks-operator.test"
 ]


### PR DESCRIPTION
[[payload.virt-handler-rhel9-container.ignore]]
error = "ErrNotDynLinked"
files = ["/usr/bin/container-disk"]

[[payload.virt-launcher-rhel9-container.ignore]]
error = "ErrNotDynLinked"
files = ["/usr/bin/container-disk"]

[[payload.virt-cdi-importer-rhel9-container.ignore]]
error = "ErrGoNotCgoEnabled"
files = [
  "/usr/bin/cdi-containerimage-server"
]

[[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
error = "ErrGoNotCgoEnabled"
files = [
  "/usr/bin/kubevirt-tekton-tasks.test"
]

[[payload.kubevirt-ssp-operator-container.ignore]]
error = "ErrGoNotCgoEnabled"
files = [
  "/usr/bin/ssp-operator.test"
]

[[payload.kubevirt-tekton-tasks-copy-template-container.ignore]]
error = "ErrGoNotCgoEnabled"
files = [
  "/usr/bin/kubevirt-tekton-tasks.test"
]

[[payload.kubevirt-tekton-tasks-operator-container.ignore]]
error = "ErrGoNotCgoEnabled"
files = [
  "/usr/bin/tekton-tasks-operator.test"
]

[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
error = "ErrGoNotCgoEnabled"
files = [
  "/usr/local/bin/disk-uploader",
  "/usr/local/bin/kubevirt-tekton-tasks.test"
]

[[payload.kubevirt-ssp-operator-rhel9-container.ignore]]
error = "ErrGoNotCgoEnabled"
files = [
  "/usr/bin/ssp-operator.test"
]

[[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
error = "ErrGoNotCgoEnabled"
files = [
  "/usr/bin/tekton-tasks-operator.test"
]