### PR TITLE
ignore rhacs client binaries

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -140,3 +140,27 @@ files = ["/usr/bin/cdi-containerimage-server"]
 [[payload.openshift-istio-cni-rhel8-container.ignore]]
 error = "ErrLibcryptoSoMissing"
 files = ["/opt/cni/bin/istio-cni-rhel9"]
+
+[[payload.rhacs-main-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+dirs = ["/assets/downloads/cli"]
+
+[[payload.rhacs-main-container.ignore]]
+error = "ErrGoNoCgoInit"
+dirs = ["/assets/downloads/cli"]
+
+[[payload.rhacs-main-container.ignore]]
+error = "ErrGoMissingSymbols"
+dirs = ["/assets/downloads/cli"]
+
+[[payload.rhacs-main-container.ignore]]
+error = "ErrNotDynLinked"
+dirs = ["/assets/downloads/cli"]
+
+[[payload.rhacs-main-container.ignore]]
+error = "ErrLibcryptoMissing"
+dirs = ["/assets/downloads/cli"]
+
+[[payload.rhacs-main-container.ignore]]
+error = "ErrGoMissingTag"
+dirs = ["/assets/downloads/cli"]


### PR DESCRIPTION
Add RHACS client binaries (downloaded from the running service by users; not executed within the fips cluster) to base exclusion from fips scanning.

RHACS and these binaries are not ocp-version specific.