### PR TITLE
[OSSM-8688] Ignore catatonit for kiali operator

### DIFF
--- a/dist/releases/4.16/config.toml
+++ b/dist/releases/4.16/config.toml
@@ -400,6 +400,10 @@ files = [
 error = "ErrNotDynLinked"
 files = ["/usr/libexec/catatonit/catatonit"]
 
+[[payload.openshift-istio-kiali-operator-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/libexec/catatonit/catatonit"]
+
 [[payload.ose-cloud-credential-operator-container.ignore]]
 error = "ErrLibcryptoSoMissing"
 files = ["/usr/bin/ccoctl", "/usr/bin/ccoctl.rhel8"]

--- a/dist/releases/4.17/config.toml
+++ b/dist/releases/4.17/config.toml
@@ -388,6 +388,10 @@ files = [
 error = "ErrNotDynLinked"
 files = ["/usr/libexec/catatonit/catatonit"]
 
+[[payload.openshift-istio-kiali-operator-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/libexec/catatonit/catatonit"]
+
 [[payload.ose-cloud-credential-operator-container.ignore]]
 error = "ErrLibcryptoSoMissing"
 files = ["/usr/bin/ccoctl", "/usr/bin/ccoctl.rhel8"]

--- a/dist/releases/4.18/config.toml
+++ b/dist/releases/4.18/config.toml
@@ -388,6 +388,10 @@ files = [
 error = "ErrNotDynLinked"
 files = ["/usr/libexec/catatonit/catatonit"]
 
+[[payload.openshift-istio-kiali-operator-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/libexec/catatonit/catatonit"]
+
 [[payload.ose-cloud-credential-operator-container.ignore]]
 error = "ErrLibcryptoSoMissing"
 files = ["/usr/bin/ccoctl", "/usr/bin/ccoctl.rhel8"]

--- a/dist/releases/4.19/config.toml
+++ b/dist/releases/4.19/config.toml
@@ -388,6 +388,10 @@ files = [
 error = "ErrNotDynLinked"
 files = ["/usr/libexec/catatonit/catatonit"]
 
+[[payload.openshift-istio-kiali-operator-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/libexec/catatonit/catatonit"]
+
 [[payload.ose-cloud-credential-operator-container.ignore]]
 error = "ErrLibcryptoSoMissing"
 files = ["/usr/bin/ccoctl", "/usr/bin/ccoctl.rhel8"]


### PR DESCRIPTION
Fips scanner reports
```
Images with failures: ===================== image: registry.redhat.io/openshift-service-mesh/kiali-rhel9-operator@sha256:25a12f12294834a58f26792989432ca246cde43eb055ccda74c8a5c8af119ebe build: openshift-istio-kiali-operator-container-2.4.1-1 check-payload failures: * /usr/libexec/catatonit/catatonit: executable is not dynamically linked
```
for our kiali operator image. 

We use `ose-ansible-rhel9-operator:v4.17.0-202412170235` as a base image for which it was resolved by https://github.com/openshift/check-payload/pull/223 .

I have added kiali operator to ignore list as well.