### PR TITLE
added to v4.19 and virt-handler ignore

### DIFF
--- a/dist/releases/4.13/config.toml
+++ b/dist/releases/4.13/config.toml
@@ -160,3 +160,7 @@ error = "ErrGoNotCgoEnabled"
 files = [
 "/usr/bin/tekton-tasks-operator.test"
 ]
+
+[[payload.virt-handler-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/bin/container-disk"]

--- a/dist/releases/4.13/config.toml
+++ b/dist/releases/4.13/config.toml
@@ -98,11 +98,9 @@ files = ["/usr/bin/cpb"]
 error = "ErrGoNotCgoEnabled"
 files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
 
-
 [[payload.hco-bundle-registry-container.ignore]]
 error = "ErrNotDynLinked"
 files = ["/usr/bin/container-disk"]
-
 
 [[payload.virt-handler-rhel9-container.ignore]]
 error = "ErrNotDynLinked"

--- a/dist/releases/4.13/config.toml
+++ b/dist/releases/4.13/config.toml
@@ -158,4 +158,3 @@ error = "ErrGoNotCgoEnabled"
 files = [
 "/usr/bin/tekton-tasks-operator.test"
 ]
-

--- a/dist/releases/4.13/config.toml
+++ b/dist/releases/4.13/config.toml
@@ -161,6 +161,3 @@ files = [
 "/usr/bin/tekton-tasks-operator.test"
 ]
 
-[[payload.virt-handler-rhel9-container.ignore]]
-error = "ErrNotDynLinked"
-files = ["/usr/bin/container-disk"]

--- a/dist/releases/4.18/config.toml
+++ b/dist/releases/4.18/config.toml
@@ -444,7 +444,8 @@ files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
 error = "ErrNotDynLinked"
 files = ["/usr/bin/container-disk"]
 
-[[payload.hco-bundle-registry-container.ignore]]
+
+[[payload.virt-handler-rhel9-container.ignore]]
 error = "ErrNotDynLinked"
 files = ["/usr/bin/container-disk"]
 
@@ -455,48 +456,52 @@ files = ["/usr/bin/container-disk"]
 [[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-  "/usr/bin/cdi-containerimage-server"
+"/usr/bin/cdi-containerimage-server"
 ]
 
 [[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-  "/usr/bin/kubevirt-tekton-tasks.test"
+"/usr/bin/kubevirt-tekton-tasks.test"
 ]
 
 [[payload.kubevirt-ssp-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-  "/usr/bin/ssp-operator.test"
+"/usr/bin/ssp-operator.test"
 ]
 
 [[payload.kubevirt-tekton-tasks-copy-template-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-  "/usr/bin/kubevirt-tekton-tasks.test"
+"/usr/bin/kubevirt-tekton-tasks.test"
 ]
 
 [[payload.kubevirt-tekton-tasks-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-  "/usr/bin/tekton-tasks-operator.test"
+"/usr/bin/tekton-tasks-operator.test"
 ]
 
 [[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-  "/usr/local/bin/disk-uploader",
-  "/usr/local/bin/kubevirt-tekton-tasks.test"
+"/usr/local/bin/disk-uploader",
+"/usr/local/bin/kubevirt-tekton-tasks.test"
 ]
 
 [[payload.kubevirt-ssp-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-  "/usr/bin/ssp-operator.test"
+"/usr/bin/ssp-operator.test"
 ]
 
 [[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-  "/usr/bin/tekton-tasks-operator.test"
+"/usr/bin/tekton-tasks-operator.test"
 ]
+
+[[payload.virt-handler-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/bin/container-disk"]

--- a/dist/releases/4.18/config.toml
+++ b/dist/releases/4.18/config.toml
@@ -500,4 +500,3 @@ error = "ErrGoNotCgoEnabled"
 files = [
 "/usr/bin/tekton-tasks-operator.test"
 ]
-

--- a/dist/releases/4.18/config.toml
+++ b/dist/releases/4.18/config.toml
@@ -502,6 +502,3 @@ files = [
 "/usr/bin/tekton-tasks-operator.test"
 ]
 
-[[payload.virt-handler-rhel9-container.ignore]]
-error = "ErrNotDynLinked"
-files = ["/usr/bin/container-disk"]

--- a/dist/releases/4.18/config.toml
+++ b/dist/releases/4.18/config.toml
@@ -444,7 +444,6 @@ files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
 error = "ErrNotDynLinked"
 files = ["/usr/bin/container-disk"]
 
-
 [[payload.virt-handler-rhel9-container.ignore]]
 error = "ErrNotDynLinked"
 files = ["/usr/bin/container-disk"]

--- a/dist/releases/4.19/config.toml
+++ b/dist/releases/4.19/config.toml
@@ -516,6 +516,3 @@ files = [
 "/usr/bin/tekton-tasks-operator.test"
 ]
 
-[[payload.virt-handler-rhel9-container.ignore]]
-error = "ErrNotDynLinked"
-files = ["/usr/bin/container-disk"]

--- a/dist/releases/4.19/config.toml
+++ b/dist/releases/4.19/config.toml
@@ -453,3 +453,69 @@ files = [
   "/usr/bin/ssp-operator.test",
   "/usr/bin/tekton-tasks-operator.test"
 ]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/bin/container-disk"]
+
+
+[[payload.virt-handler-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/bin/container-disk"]
+
+[[payload.virt-launcher-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/bin/container-disk"]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+"/usr/bin/cdi-containerimage-server"
+]
+
+[[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+"/usr/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-ssp-operator-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+"/usr/bin/ssp-operator.test"
+]
+
+[[payload.kubevirt-tekton-tasks-copy-template-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+"/usr/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-tekton-tasks-operator-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+"/usr/bin/tekton-tasks-operator.test"
+]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+"/usr/local/bin/disk-uploader",
+"/usr/local/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-ssp-operator-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+"/usr/bin/ssp-operator.test"
+]
+
+[[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+"/usr/bin/tekton-tasks-operator.test"
+]
+
+[[payload.virt-handler-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/bin/container-disk"]

--- a/dist/releases/4.19/config.toml
+++ b/dist/releases/4.19/config.toml
@@ -515,4 +515,3 @@ error = "ErrGoNotCgoEnabled"
 files = [
 "/usr/bin/tekton-tasks-operator.test"
 ]
-


### PR DESCRIPTION
as we move to v4.19 update the config for 4.19 and added missing:

```
[[payload.virt-handler-rhel9-container.ignore]]
error = "ErrNotDynLinked"
files = ["/usr/bin/container-disk"]
```

