### PR TITLE
added missing ignore and extand to all versions

### DIFF
--- a/dist/releases/4.12/config.toml
+++ b/dist/releases/4.12/config.toml
@@ -254,3 +254,7 @@ files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 [[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = ["/usr/bin/tekton-tasks-operator.test"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/local/bin/disk-uploader"]

--- a/dist/releases/4.12/config.toml
+++ b/dist/releases/4.12/config.toml
@@ -262,3 +262,7 @@ files = ["/usr/local/bin/disk-uploader"]
 [[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
 error = "ErrGoMissingSymbols"
 files = ["/usr/local/bin/disk-uploader"]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/local/bin/disk-uploader"]

--- a/dist/releases/4.12/config.toml
+++ b/dist/releases/4.12/config.toml
@@ -37,3 +37,269 @@ files = ["/usr/bin/cpb"]
 [[payload.operator-lifecycle-manager-container.ignore]]
 error = "ErrLibcryptoMissing"
 files = ["/usr/bin/cpb"]
+
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/cdi-containerimage-server",
+  "/usr/local/bin/disk-uploader",
+  "/usr/local/bin/kubevirt-tekton-tasks.test",
+  "/usr/bin/ssp-operator.test",
+  "/usr/bin/tekton-tasks-operator.test"
+]
+
+[[payload.virt-handler-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.virt-launcher-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/cdi-containerimage-server"
+]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = [
+  "/usr/bin/cdi-containerimage-server"
+]
+
+[[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-ssp-operator-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/ssp-operator.test"
+]
+
+[[payload.kubevirt-tekton-tasks-copy-template-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-tekton-tasks-operator-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/tekton-tasks-operator.test"
+]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/local/bin/disk-uploader",
+  "/usr/local/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-ssp-operator-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/ssp-operator.test"
+]
+
+[[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/tekton-tasks-operator.test"
+]
+
+[[payload.kubevirt-tekton-tasks-operator-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/tekton-tasks-operator.test"
+]
+
+[[payload.virt-handler-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.virt-cdi-importer-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/cdi-containerimage-server"
+]
+
+[[payload.virt-launcher-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.hyperconverged-cluster-webhook-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/hyperconverged-cluster-webhook"
+]
+
+[[payload.cluster-network-addons-operator-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/cluster-network-addons-operator",
+  "/manifest-templator"
+]
+
+[[payload.bridge-marker-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/bridge-marker"
+]
+
+[[payload.vm-network-latency-checkup-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/checkups/kubevirt-vm-latency"
+]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/modify-data-object"
+]
+
+[[payload.kubemacpool-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/manager"
+]
+
+[[payload.virt-exportserver-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/virt-exportserver"
+]
+
+[[payload.virt-exportproxy-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/virt-exportproxy"
+]
+
+[[payload.kubevirt-tekton-tasks-create-vm-from-template-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/create-vm"
+]
+
+[[payload.kubevirt-tekton-tasks-disk-virt-customize-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/disk-virt-customize"
+]
+
+[[payload.kubevirt-tekton-tasks-wait-for-vmi-status-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/wait-for-vmi-status"
+]
+
+[[payload.cnv-must-gather-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/bin/vmConvertor"
+]
+
+[[payload.cnv-containernetworking-plugins-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/src/github.com/containernetworking/plugins/bin/bridge",
+  "/usr/src/github.com/containernetworking/plugins/bin/tuning"
+]
+
+[[payload.kubevirt-tekton-tasks-cleanup-vm-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/execute-in-vm"
+]
+
+[[payload.virt-api-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/virt-api"
+]
+
+[[payload.virt-operator-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/csv-generator",
+  "/usr/bin/virt-operator"
+]
+
+[[payload.kubevirt-tekton-tasks-disk-virt-sysprep-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/disk-virt-sysprep"
+]
+
+[[payload.ovs-cni-marker-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/src/ovs-cni/bin/ovs-marker"
+]
+
+[[payload.kubevirt-tekton-tasks-modify-vm-template-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/modify-vm-template"
+]
+
+[[payload.hyperconverged-cluster-operator-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/csv-merger",
+  "/usr/local/bin/hyperconverged-cluster-operator"
+]
+
+[[payload.kubevirt-template-validator-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/sbin/kubevirt-template-validator"
+]
+
+[[payload.virt-controller-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/virt-controller"
+]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/marker",
+  "/ovs",
+  "/ovs-mirror-consumer",
+  "/ovs-mirror-producer"
+]
+
+[[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/tekton-tasks-operator.test"
+]
+

--- a/dist/releases/4.12/config.toml
+++ b/dist/releases/4.12/config.toml
@@ -258,3 +258,7 @@ files = ["/usr/bin/tekton-tasks-operator.test"]
 [[payload.hco-bundle-registry-container.ignore]]
 error = "ErrGoMissingSymbols"
 files = ["/usr/local/bin/disk-uploader"]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/local/bin/disk-uploader"]

--- a/dist/releases/4.12/config.toml
+++ b/dist/releases/4.12/config.toml
@@ -41,265 +41,216 @@ files = ["/usr/bin/cpb"]
 
 [[payload.hco-bundle-registry-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.hco-bundle-registry-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/cdi-containerimage-server",
-  "/usr/local/bin/disk-uploader",
-  "/usr/local/bin/kubevirt-tekton-tasks.test",
-  "/usr/bin/ssp-operator.test",
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/local/bin/disk-uploader"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/local/bin/kubevirt-tekton-tasks.test"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/ssp-operator.test"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.virt-handler-rhel9-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.virt-launcher-rhel9-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/cdi-containerimage-server"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
 
 [[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoMissingSymbols"
-files = [
-  "/usr/bin/cdi-containerimage-server"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
 
 [[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/kubevirt-tekton-tasks.test"
-]
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-ssp-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/ssp-operator.test"
-]
+files = ["/usr/bin/ssp-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-copy-template-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/kubevirt-tekton-tasks.test"
-]
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/local/bin/disk-uploader",
-  "/usr/local/bin/kubevirt-tekton-tasks.test"
-]
+files = ["/usr/local/bin/disk-uploader"]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/local/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-ssp-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/ssp-operator.test"
-]
+files = ["/usr/bin/ssp-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.virt-handler-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.virt-cdi-importer-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/cdi-containerimage-server"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
 
 [[payload.virt-launcher-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.hyperconverged-cluster-webhook-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/hyperconverged-cluster-webhook"
-]
+files = ["/usr/local/bin/hyperconverged-cluster-webhook"]
 
 [[payload.cluster-network-addons-operator-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/cluster-network-addons-operator",
-  "/manifest-templator"
-]
+files = ["/cluster-network-addons-operator"]
+
+[[payload.cluster-network-addons-operator-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/manifest-templator"]
 
 [[payload.bridge-marker-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/bridge-marker"
-]
+files = ["/bridge-marker"]
 
 [[payload.vm-network-latency-checkup-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/checkups/kubevirt-vm-latency"
-]
+files = ["/checkups/kubevirt-vm-latency"]
 
 [[payload.kubevirt-tekton-tasks-create-datavolume-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/modify-data-object"
-]
+files = ["/usr/local/bin/modify-data-object"]
 
 [[payload.kubemacpool-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/manager"
-]
+files = ["/manager"]
 
 [[payload.virt-exportserver-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/virt-exportserver"
-]
+files = ["/usr/bin/virt-exportserver"]
 
 [[payload.virt-exportproxy-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/virt-exportproxy"
-]
+files = ["/usr/bin/virt-exportproxy"]
 
 [[payload.kubevirt-tekton-tasks-create-vm-from-template-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/create-vm"
-]
+files = ["/usr/local/bin/create-vm"]
 
 [[payload.kubevirt-tekton-tasks-disk-virt-customize-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/disk-virt-customize"
-]
+files = ["/usr/local/bin/disk-virt-customize"]
 
 [[payload.kubevirt-tekton-tasks-wait-for-vmi-status-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/wait-for-vmi-status"
-]
+files = ["/usr/local/bin/wait-for-vmi-status"]
 
 [[payload.cnv-must-gather-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/bin/vmConvertor"
-]
+files = ["/usr/bin/vmConvertor"]
 
 [[payload.cnv-containernetworking-plugins-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/src/github.com/containernetworking/plugins/bin/bridge",
-  "/usr/src/github.com/containernetworking/plugins/bin/tuning"
-]
+files = ["/usr/src/github.com/containernetworking/plugins/bin/bridge"]
+
+[[payload.cnv-containernetworking-plugins-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/usr/src/github.com/containernetworking/plugins/bin/tuning"]
 
 [[payload.kubevirt-tekton-tasks-cleanup-vm-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/execute-in-vm"
-]
+files = ["/usr/local/bin/execute-in-vm"]
 
 [[payload.virt-api-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/virt-api"
-]
+files = ["/usr/bin/virt-api"]
 
 [[payload.virt-operator-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/csv-generator",
-  "/usr/bin/virt-operator"
-]
+files = ["/usr/bin/csv-generator"]
+
+[[payload.virt-operator-container.ignore]]
+error = "ErrGoMissingTag"
+files = ["/usr/bin/virt-operator"]
 
 [[payload.kubevirt-tekton-tasks-disk-virt-sysprep-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/disk-virt-sysprep"
-]
+files = ["/usr/local/bin/disk-virt-sysprep"]
 
 [[payload.ovs-cni-marker-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/src/ovs-cni/bin/ovs-marker"
-]
+files = ["/usr/src/ovs-cni/bin/ovs-marker"]
 
 [[payload.kubevirt-tekton-tasks-modify-vm-template-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/modify-vm-template"
-]
+files = ["/usr/local/bin/modify-vm-template"]
 
 [[payload.hyperconverged-cluster-operator-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/csv-merger",
-  "/usr/local/bin/hyperconverged-cluster-operator"
-]
+files = ["/usr/local/bin/csv-merger"]
+
+[[payload.hyperconverged-cluster-operator-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/usr/local/bin/hyperconverged-cluster-operator"]
 
 [[payload.kubevirt-template-validator-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/sbin/kubevirt-template-validator"
-]
+files = ["/usr/sbin/kubevirt-template-validator"]
 
 [[payload.virt-controller-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/virt-controller"
-]
+files = ["/usr/bin/virt-controller"]
 
 [[payload.ovs-cni-plugin-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/marker",
-  "/ovs",
-  "/ovs-mirror-consumer",
-  "/ovs-mirror-producer"
-]
+files = ["/marker"]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/ovs"]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/ovs-mirror-consumer"]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/ovs-mirror-producer"]
 
 [[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/kubevirt-tekton-tasks.test"
-]
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/tekton-tasks-operator.test"
-]
-
+files = ["/usr/bin/tekton-tasks-operator.test"]

--- a/dist/releases/4.13/config.toml
+++ b/dist/releases/4.13/config.toml
@@ -323,3 +323,7 @@ files = ["/usr/local/bin/disk-uploader"]
 [[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
 error = "ErrGoMissingSymbols"
 files = ["/usr/local/bin/disk-uploader"]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/local/bin/disk-uploader"]

--- a/dist/releases/4.13/config.toml
+++ b/dist/releases/4.13/config.toml
@@ -102,264 +102,216 @@ files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
 
 [[payload.hco-bundle-registry-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.hco-bundle-registry-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/cdi-containerimage-server",
-  "/usr/local/bin/disk-uploader",
-  "/usr/local/bin/kubevirt-tekton-tasks.test",
-  "/usr/bin/ssp-operator.test",
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/local/bin/disk-uploader"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/local/bin/kubevirt-tekton-tasks.test"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/ssp-operator.test"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.virt-handler-rhel9-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.virt-launcher-rhel9-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/cdi-containerimage-server"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
 
 [[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoMissingSymbols"
-files = [
-  "/usr/bin/cdi-containerimage-server"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
 
 [[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/kubevirt-tekton-tasks.test"
-]
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-ssp-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/ssp-operator.test"
-]
+files = ["/usr/bin/ssp-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-copy-template-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/kubevirt-tekton-tasks.test"
-]
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/local/bin/disk-uploader",
-  "/usr/local/bin/kubevirt-tekton-tasks.test"
-]
+files = ["/usr/local/bin/disk-uploader"]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/local/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-ssp-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/ssp-operator.test"
-]
+files = ["/usr/bin/ssp-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.virt-handler-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.virt-cdi-importer-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/cdi-containerimage-server"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
 
 [[payload.virt-launcher-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.hyperconverged-cluster-webhook-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/hyperconverged-cluster-webhook"
-]
+files = ["/usr/local/bin/hyperconverged-cluster-webhook"]
 
 [[payload.cluster-network-addons-operator-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/cluster-network-addons-operator",
-  "/manifest-templator"
-]
+files = ["/cluster-network-addons-operator"]
+
+[[payload.cluster-network-addons-operator-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/manifest-templator"]
 
 [[payload.bridge-marker-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/bridge-marker"
-]
+files = ["/bridge-marker"]
 
 [[payload.vm-network-latency-checkup-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/checkups/kubevirt-vm-latency"
-]
+files = ["/checkups/kubevirt-vm-latency"]
 
 [[payload.kubevirt-tekton-tasks-create-datavolume-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/modify-data-object"
-]
+files = ["/usr/local/bin/modify-data-object"]
 
 [[payload.kubemacpool-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/manager"
-]
+files = ["/manager"]
 
 [[payload.virt-exportserver-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/virt-exportserver"
-]
+files = ["/usr/bin/virt-exportserver"]
 
 [[payload.virt-exportproxy-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/virt-exportproxy"
-]
+files = ["/usr/bin/virt-exportproxy"]
 
 [[payload.kubevirt-tekton-tasks-create-vm-from-template-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/create-vm"
-]
+files = ["/usr/local/bin/create-vm"]
 
 [[payload.kubevirt-tekton-tasks-disk-virt-customize-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/disk-virt-customize"
-]
+files = ["/usr/local/bin/disk-virt-customize"]
 
 [[payload.kubevirt-tekton-tasks-wait-for-vmi-status-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/wait-for-vmi-status"
-]
+files = ["/usr/local/bin/wait-for-vmi-status"]
 
 [[payload.cnv-must-gather-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/bin/vmConvertor"
-]
+files = ["/usr/bin/vmConvertor"]
 
 [[payload.cnv-containernetworking-plugins-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/src/github.com/containernetworking/plugins/bin/bridge",
-  "/usr/src/github.com/containernetworking/plugins/bin/tuning"
-]
+files = ["/usr/src/github.com/containernetworking/plugins/bin/bridge"]
+
+[[payload.cnv-containernetworking-plugins-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/usr/src/github.com/containernetworking/plugins/bin/tuning"]
 
 [[payload.kubevirt-tekton-tasks-cleanup-vm-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/execute-in-vm"
-]
+files = ["/usr/local/bin/execute-in-vm"]
 
 [[payload.virt-api-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/virt-api"
-]
+files = ["/usr/bin/virt-api"]
 
 [[payload.virt-operator-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/csv-generator",
-  "/usr/bin/virt-operator"
-]
+files = ["/usr/bin/csv-generator"]
+
+[[payload.virt-operator-container.ignore]]
+error = "ErrGoMissingTag"
+files = ["/usr/bin/virt-operator"]
 
 [[payload.kubevirt-tekton-tasks-disk-virt-sysprep-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/disk-virt-sysprep"
-]
+files = ["/usr/local/bin/disk-virt-sysprep"]
 
 [[payload.ovs-cni-marker-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/src/ovs-cni/bin/ovs-marker"
-]
+files = ["/usr/src/ovs-cni/bin/ovs-marker"]
 
 [[payload.kubevirt-tekton-tasks-modify-vm-template-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/modify-vm-template"
-]
+files = ["/usr/local/bin/modify-vm-template"]
 
 [[payload.hyperconverged-cluster-operator-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/csv-merger",
-  "/usr/local/bin/hyperconverged-cluster-operator"
-]
+files = ["/usr/local/bin/csv-merger"]
+
+[[payload.hyperconverged-cluster-operator-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/usr/local/bin/hyperconverged-cluster-operator"]
 
 [[payload.kubevirt-template-validator-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/sbin/kubevirt-template-validator"
-]
+files = ["/usr/sbin/kubevirt-template-validator"]
 
 [[payload.virt-controller-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/virt-controller"
-]
+files = ["/usr/bin/virt-controller"]
 
 [[payload.ovs-cni-plugin-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/marker",
-  "/ovs",
-  "/ovs-mirror-consumer",
-  "/ovs-mirror-producer"
-]
+files = ["/marker"]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/ovs"]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/ovs-mirror-consumer"]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/ovs-mirror-producer"]
 
 [[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/kubevirt-tekton-tasks.test"
-]
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]

--- a/dist/releases/4.13/config.toml
+++ b/dist/releases/4.13/config.toml
@@ -315,3 +315,7 @@ files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 [[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = ["/usr/bin/tekton-tasks-operator.test"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/local/bin/disk-uploader"]

--- a/dist/releases/4.13/config.toml
+++ b/dist/releases/4.13/config.toml
@@ -98,63 +98,268 @@ files = ["/usr/bin/cpb"]
 error = "ErrGoNotCgoEnabled"
 files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
 
+
+
 [[payload.hco-bundle-registry-container.ignore]]
 error = "ErrNotDynLinked"
-files = ["/usr/bin/container-disk"]
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/cdi-containerimage-server",
+  "/usr/local/bin/disk-uploader",
+  "/usr/local/bin/kubevirt-tekton-tasks.test",
+  "/usr/bin/ssp-operator.test",
+  "/usr/bin/tekton-tasks-operator.test"
+]
 
 [[payload.virt-handler-rhel9-container.ignore]]
 error = "ErrNotDynLinked"
-files = ["/usr/bin/container-disk"]
+files = [
+  "/usr/bin/container-disk"
+]
 
 [[payload.virt-launcher-rhel9-container.ignore]]
 error = "ErrNotDynLinked"
-files = ["/usr/bin/container-disk"]
+files = [
+  "/usr/bin/container-disk"
+]
 
 [[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-"/usr/bin/cdi-containerimage-server"
+  "/usr/bin/cdi-containerimage-server"
+]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = [
+  "/usr/bin/cdi-containerimage-server"
 ]
 
 [[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-"/usr/bin/kubevirt-tekton-tasks.test"
+  "/usr/bin/kubevirt-tekton-tasks.test"
 ]
 
 [[payload.kubevirt-ssp-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-"/usr/bin/ssp-operator.test"
+  "/usr/bin/ssp-operator.test"
 ]
 
 [[payload.kubevirt-tekton-tasks-copy-template-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-"/usr/bin/kubevirt-tekton-tasks.test"
+  "/usr/bin/kubevirt-tekton-tasks.test"
 ]
 
 [[payload.kubevirt-tekton-tasks-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-"/usr/bin/tekton-tasks-operator.test"
+  "/usr/bin/tekton-tasks-operator.test"
 ]
 
 [[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-"/usr/local/bin/disk-uploader",
-"/usr/local/bin/kubevirt-tekton-tasks.test"
+  "/usr/local/bin/disk-uploader",
+  "/usr/local/bin/kubevirt-tekton-tasks.test"
 ]
 
 [[payload.kubevirt-ssp-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-"/usr/bin/ssp-operator.test"
+  "/usr/bin/ssp-operator.test"
 ]
 
 [[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-"/usr/bin/tekton-tasks-operator.test"
+  "/usr/bin/tekton-tasks-operator.test"
+]
+
+[[payload.kubevirt-tekton-tasks-operator-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/tekton-tasks-operator.test"
+]
+
+[[payload.virt-handler-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.virt-cdi-importer-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/cdi-containerimage-server"
+]
+
+[[payload.virt-launcher-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.hyperconverged-cluster-webhook-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/hyperconverged-cluster-webhook"
+]
+
+[[payload.cluster-network-addons-operator-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/cluster-network-addons-operator",
+  "/manifest-templator"
+]
+
+[[payload.bridge-marker-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/bridge-marker"
+]
+
+[[payload.vm-network-latency-checkup-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/checkups/kubevirt-vm-latency"
+]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/modify-data-object"
+]
+
+[[payload.kubemacpool-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/manager"
+]
+
+[[payload.virt-exportserver-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/virt-exportserver"
+]
+
+[[payload.virt-exportproxy-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/virt-exportproxy"
+]
+
+[[payload.kubevirt-tekton-tasks-create-vm-from-template-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/create-vm"
+]
+
+[[payload.kubevirt-tekton-tasks-disk-virt-customize-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/disk-virt-customize"
+]
+
+[[payload.kubevirt-tekton-tasks-wait-for-vmi-status-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/wait-for-vmi-status"
+]
+
+[[payload.cnv-must-gather-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/bin/vmConvertor"
+]
+
+[[payload.cnv-containernetworking-plugins-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/src/github.com/containernetworking/plugins/bin/bridge",
+  "/usr/src/github.com/containernetworking/plugins/bin/tuning"
+]
+
+[[payload.kubevirt-tekton-tasks-cleanup-vm-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/execute-in-vm"
+]
+
+[[payload.virt-api-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/virt-api"
+]
+
+[[payload.virt-operator-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/csv-generator",
+  "/usr/bin/virt-operator"
+]
+
+[[payload.kubevirt-tekton-tasks-disk-virt-sysprep-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/disk-virt-sysprep"
+]
+
+[[payload.ovs-cni-marker-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/src/ovs-cni/bin/ovs-marker"
+]
+
+[[payload.kubevirt-tekton-tasks-modify-vm-template-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/modify-vm-template"
+]
+
+[[payload.hyperconverged-cluster-operator-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/csv-merger",
+  "/usr/local/bin/hyperconverged-cluster-operator"
+]
+
+[[payload.kubevirt-template-validator-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/sbin/kubevirt-template-validator"
+]
+
+[[payload.virt-controller-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/virt-controller"
+]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/marker",
+  "/ovs",
+  "/ovs-mirror-consumer",
+  "/ovs-mirror-producer"
+]
+
+[[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/tekton-tasks-operator.test"
 ]

--- a/dist/releases/4.13/config.toml
+++ b/dist/releases/4.13/config.toml
@@ -319,3 +319,7 @@ files = ["/usr/bin/tekton-tasks-operator.test"]
 [[payload.hco-bundle-registry-container.ignore]]
 error = "ErrGoMissingSymbols"
 files = ["/usr/local/bin/disk-uploader"]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/local/bin/disk-uploader"]

--- a/dist/releases/4.14/config.toml
+++ b/dist/releases/4.14/config.toml
@@ -404,3 +404,7 @@ files = ["/usr/local/bin/disk-uploader"]
 [[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
 error = "ErrGoMissingSymbols"
 files = ["/usr/local/bin/disk-uploader"]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/local/bin/disk-uploader"]

--- a/dist/releases/4.14/config.toml
+++ b/dist/releases/4.14/config.toml
@@ -150,234 +150,219 @@ files = ["/usr/bin/rhel8/sriov"]
 
 [[payload.hco-bundle-registry-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.hco-bundle-registry-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/cdi-containerimage-server",
-  "/usr/local/bin/disk-uploader",
-  "/usr/local/bin/kubevirt-tekton-tasks.test",
-  "/usr/bin/ssp-operator.test",
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/local/bin/disk-uploader"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/local/bin/kubevirt-tekton-tasks.test"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/ssp-operator.test"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.virt-handler-rhel9-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.virt-launcher-rhel9-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/cdi-containerimage-server"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
 
 [[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoMissingSymbols"
-files = [
-  "/usr/bin/cdi-containerimage-server"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
 
 [[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/kubevirt-tekton-tasks.test"
-]
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-ssp-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/ssp-operator.test"
-]
+files = ["/usr/bin/ssp-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-copy-template-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/kubevirt-tekton-tasks.test"
-]
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/local/bin/disk-uploader",
-  "/usr/local/bin/kubevirt-tekton-tasks.test"
-]
+files = ["/usr/local/bin/disk-uploader"]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/local/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-ssp-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/ssp-operator.test"
-]
+files = ["/usr/bin/ssp-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.virt-handler-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.virt-cdi-importer-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/cdi-containerimage-server"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
 
 [[payload.virt-launcher-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.hyperconverged-cluster-webhook-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/hyperconverged-cluster-webhook"
-]
+files = ["/usr/local/bin/hyperconverged-cluster-webhook"]
 
 [[payload.cluster-network-addons-operator-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/cluster-network-addons-operator",
-  "/manifest-templator"
-]
+files = ["/cluster-network-addons-operator"]
+
+[[payload.cluster-network-addons-operator-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/manifest-templator"]
 
 [[payload.bridge-marker-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/bridge-marker"
-]
+files = ["/bridge-marker"]
 
 [[payload.vm-network-latency-checkup-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/checkups/kubevirt-vm-latency"
-]
+files = ["/checkups/kubevirt-vm-latency"]
 
 [[payload.kubevirt-tekton-tasks-create-datavolume-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/modify-data-object"
-]
+files = ["/usr/local/bin/modify-data-object"]
 
 [[payload.kubemacpool-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/manager"
-]
+files = ["/manager"]
 
 [[payload.virt-exportserver-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/virt-exportserver"
-]
+files = ["/usr/bin/virt-exportserver"]
 
 [[payload.virt-exportproxy-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/virt-exportproxy"
-]
+files = ["/usr/bin/virt-exportproxy"]
 
 [[payload.kubevirt-tekton-tasks-create-vm-from-template-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/create-vm"
-]
+files = ["/usr/local/bin/create-vm"]
 
 [[payload.kubevirt-tekton-tasks-disk-virt-customize-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/disk-virt-customize"
-]
+files = ["/usr/local/bin/disk-virt-customize"]
 
 [[payload.kubevirt-tekton-tasks-wait-for-vmi-status-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/wait-for-vmi-status"
-]
+files = ["/usr/local/bin/wait-for-vmi-status"]
 
 [[payload.cnv-must-gather-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/bin/vmConvertor"
-]
+files = ["/usr/bin/vmConvertor"]
 
 [[payload.cnv-containernetworking-plugins-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/src/github.com/containernetworking/plugins/bin/bridge",
-  "/usr/src/github.com/containernetworking/plugins/bin/tuning"
-]
+files = ["/usr/src/github.com/containernetworking/plugins/bin/bridge"]
+
+[[payload.cnv-containernetworking-plugins-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/usr/src/github.com/containernetworking/plugins/bin/tuning"]
 
 [[payload.kubevirt-tekton-tasks-cleanup-vm-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/execute-in-vm"
-]
+files = ["/usr/local/bin/execute-in-vm"]
 
 [[payload.virt-api-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/virt-api"
-]
+files = ["/usr/bin/virt-api"]
 
 [[payload.virt-operator-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/csv-generator",
-  "/usr/bin/virt-operator"
-]
+files = ["/usr/bin/csv-generator"]
+
+[[payload.virt-operator-container.ignore]]
+error = "ErrGoMissingTag"
+files = ["/usr/bin/virt-operator"]
 
 [[payload.kubevirt-tekton-tasks-disk-virt-sysprep-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/disk-virt-sysprep"
-]
+files = ["/usr/local/bin/disk-virt-sysprep"]
 
 [[payload.ovs-cni-marker-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/src/ovs-cni/bin/ovs-marker"
-]
+files = ["/usr/src/ovs-cni/bin/ovs-marker"]
 
 [[payload.kubevirt-tekton-tasks-modify-vm-template-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/modify-vm-template"
-]
+files = ["/usr/local/bin/modify-vm-template"]
 
 [[payload.hyperconverged-cluster-operator-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/csv-merger",
-  "/usr/local/bin/hyperconverged-cluster-operator"
-]
+files = ["/usr/local/bin/csv-merger"]
+
+[[payload.hyperconverged-cluster-operator-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/usr/local/bin/hyperconverged-cluster-operator"]
+
+[[payload.kubevirt-template-validator-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/usr/sbin/kubevirt-template-validator"]
+
+[[payload.virt-controller-container.ignore]]
+error = "ErrGoMissingTag"
+files = ["/usr/bin/virt-controller"]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/marker"]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/ovs"]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/ovs-mirror-consumer"]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/ovs-mirror-producer"]
+
+[[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
+
+[[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.kubevirt-template-validator-container.ignore]]
 error = "ErrGoNoTags"

--- a/dist/releases/4.14/config.toml
+++ b/dist/releases/4.14/config.toml
@@ -396,3 +396,7 @@ error = "ErrGoNotCgoEnabled"
 files = [
   "/usr/bin/tekton-tasks-operator.test"
 ]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/local/bin/disk-uploader"]

--- a/dist/releases/4.14/config.toml
+++ b/dist/releases/4.14/config.toml
@@ -400,3 +400,7 @@ files = [
 [[payload.hco-bundle-registry-container.ignore]]
 error = "ErrGoMissingSymbols"
 files = ["/usr/local/bin/disk-uploader"]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/local/bin/disk-uploader"]

--- a/dist/releases/4.14/config.toml
+++ b/dist/releases/4.14/config.toml
@@ -147,3 +147,267 @@ files = ["/usr/bin/ib-sriov"]
 [[payload.sriov-cni-container.ignore]]
 error = "ErrLibcryptoSoMissing"
 files = ["/usr/bin/rhel8/sriov"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/cdi-containerimage-server",
+  "/usr/local/bin/disk-uploader",
+  "/usr/local/bin/kubevirt-tekton-tasks.test",
+  "/usr/bin/ssp-operator.test",
+  "/usr/bin/tekton-tasks-operator.test"
+]
+
+[[payload.virt-handler-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.virt-launcher-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/cdi-containerimage-server"
+]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = [
+  "/usr/bin/cdi-containerimage-server"
+]
+
+[[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-ssp-operator-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/ssp-operator.test"
+]
+
+[[payload.kubevirt-tekton-tasks-copy-template-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-tekton-tasks-operator-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/tekton-tasks-operator.test"
+]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/local/bin/disk-uploader",
+  "/usr/local/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-ssp-operator-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/ssp-operator.test"
+]
+
+[[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/tekton-tasks-operator.test"
+]
+
+[[payload.kubevirt-tekton-tasks-operator-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/tekton-tasks-operator.test"
+]
+
+[[payload.virt-handler-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.virt-cdi-importer-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/cdi-containerimage-server"
+]
+
+[[payload.virt-launcher-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.hyperconverged-cluster-webhook-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/hyperconverged-cluster-webhook"
+]
+
+[[payload.cluster-network-addons-operator-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/cluster-network-addons-operator",
+  "/manifest-templator"
+]
+
+[[payload.bridge-marker-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/bridge-marker"
+]
+
+[[payload.vm-network-latency-checkup-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/checkups/kubevirt-vm-latency"
+]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/modify-data-object"
+]
+
+[[payload.kubemacpool-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/manager"
+]
+
+[[payload.virt-exportserver-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/virt-exportserver"
+]
+
+[[payload.virt-exportproxy-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/virt-exportproxy"
+]
+
+[[payload.kubevirt-tekton-tasks-create-vm-from-template-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/create-vm"
+]
+
+[[payload.kubevirt-tekton-tasks-disk-virt-customize-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/disk-virt-customize"
+]
+
+[[payload.kubevirt-tekton-tasks-wait-for-vmi-status-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/wait-for-vmi-status"
+]
+
+[[payload.cnv-must-gather-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/bin/vmConvertor"
+]
+
+[[payload.cnv-containernetworking-plugins-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/src/github.com/containernetworking/plugins/bin/bridge",
+  "/usr/src/github.com/containernetworking/plugins/bin/tuning"
+]
+
+[[payload.kubevirt-tekton-tasks-cleanup-vm-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/execute-in-vm"
+]
+
+[[payload.virt-api-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/virt-api"
+]
+
+[[payload.virt-operator-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/csv-generator",
+  "/usr/bin/virt-operator"
+]
+
+[[payload.kubevirt-tekton-tasks-disk-virt-sysprep-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/disk-virt-sysprep"
+]
+
+[[payload.ovs-cni-marker-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/src/ovs-cni/bin/ovs-marker"
+]
+
+[[payload.kubevirt-tekton-tasks-modify-vm-template-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/modify-vm-template"
+]
+
+[[payload.hyperconverged-cluster-operator-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/csv-merger",
+  "/usr/local/bin/hyperconverged-cluster-operator"
+]
+
+[[payload.kubevirt-template-validator-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/sbin/kubevirt-template-validator"
+]
+
+[[payload.virt-controller-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/virt-controller"
+]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/marker",
+  "/ovs",
+  "/ovs-mirror-consumer",
+  "/ovs-mirror-producer"
+]
+
+[[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/tekton-tasks-operator.test"
+]

--- a/dist/releases/4.15/config.toml
+++ b/dist/releases/4.15/config.toml
@@ -174,264 +174,216 @@ files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
 
 [[payload.hco-bundle-registry-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.hco-bundle-registry-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/cdi-containerimage-server",
-  "/usr/local/bin/disk-uploader",
-  "/usr/local/bin/kubevirt-tekton-tasks.test",
-  "/usr/bin/ssp-operator.test",
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/local/bin/disk-uploader"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/local/bin/kubevirt-tekton-tasks.test"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/ssp-operator.test"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.virt-handler-rhel9-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.virt-launcher-rhel9-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/cdi-containerimage-server"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
 
 [[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoMissingSymbols"
-files = [
-  "/usr/bin/cdi-containerimage-server"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
 
 [[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/kubevirt-tekton-tasks.test"
-]
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-ssp-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/ssp-operator.test"
-]
+files = ["/usr/bin/ssp-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-copy-template-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/kubevirt-tekton-tasks.test"
-]
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/local/bin/disk-uploader",
-  "/usr/local/bin/kubevirt-tekton-tasks.test"
-]
+files = ["/usr/local/bin/disk-uploader"]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/local/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-ssp-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/ssp-operator.test"
-]
+files = ["/usr/bin/ssp-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.virt-handler-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.virt-cdi-importer-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/cdi-containerimage-server"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
 
 [[payload.virt-launcher-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.hyperconverged-cluster-webhook-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/hyperconverged-cluster-webhook"
-]
+files = ["/usr/local/bin/hyperconverged-cluster-webhook"]
 
 [[payload.cluster-network-addons-operator-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/cluster-network-addons-operator",
-  "/manifest-templator"
-]
+files = ["/cluster-network-addons-operator"]
+
+[[payload.cluster-network-addons-operator-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/manifest-templator"]
 
 [[payload.bridge-marker-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/bridge-marker"
-]
+files = ["/bridge-marker"]
 
 [[payload.vm-network-latency-checkup-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/checkups/kubevirt-vm-latency"
-]
+files = ["/checkups/kubevirt-vm-latency"]
 
 [[payload.kubevirt-tekton-tasks-create-datavolume-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/modify-data-object"
-]
+files = ["/usr/local/bin/modify-data-object"]
 
 [[payload.kubemacpool-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/manager"
-]
+files = ["/manager"]
 
 [[payload.virt-exportserver-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/virt-exportserver"
-]
+files = ["/usr/bin/virt-exportserver"]
 
 [[payload.virt-exportproxy-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/virt-exportproxy"
-]
+files = ["/usr/bin/virt-exportproxy"]
 
 [[payload.kubevirt-tekton-tasks-create-vm-from-template-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/create-vm"
-]
+files = ["/usr/local/bin/create-vm"]
 
 [[payload.kubevirt-tekton-tasks-disk-virt-customize-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/disk-virt-customize"
-]
+files = ["/usr/local/bin/disk-virt-customize"]
 
 [[payload.kubevirt-tekton-tasks-wait-for-vmi-status-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/wait-for-vmi-status"
-]
+files = ["/usr/local/bin/wait-for-vmi-status"]
 
 [[payload.cnv-must-gather-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/bin/vmConvertor"
-]
+files = ["/usr/bin/vmConvertor"]
 
 [[payload.cnv-containernetworking-plugins-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/src/github.com/containernetworking/plugins/bin/bridge",
-  "/usr/src/github.com/containernetworking/plugins/bin/tuning"
-]
+files = ["/usr/src/github.com/containernetworking/plugins/bin/bridge"]
+
+[[payload.cnv-containernetworking-plugins-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/usr/src/github.com/containernetworking/plugins/bin/tuning"]
 
 [[payload.kubevirt-tekton-tasks-cleanup-vm-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/execute-in-vm"
-]
+files = ["/usr/local/bin/execute-in-vm"]
 
 [[payload.virt-api-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/virt-api"
-]
+files = ["/usr/bin/virt-api"]
 
 [[payload.virt-operator-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/csv-generator",
-  "/usr/bin/virt-operator"
-]
+files = ["/usr/bin/csv-generator"]
+
+[[payload.virt-operator-container.ignore]]
+error = "ErrGoMissingTag"
+files = ["/usr/bin/virt-operator"]
 
 [[payload.kubevirt-tekton-tasks-disk-virt-sysprep-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/disk-virt-sysprep"
-]
+files = ["/usr/local/bin/disk-virt-sysprep"]
 
 [[payload.ovs-cni-marker-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/src/ovs-cni/bin/ovs-marker"
-]
+files = ["/usr/src/ovs-cni/bin/ovs-marker"]
 
 [[payload.kubevirt-tekton-tasks-modify-vm-template-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/modify-vm-template"
-]
+files = ["/usr/local/bin/modify-vm-template"]
 
 [[payload.hyperconverged-cluster-operator-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/csv-merger",
-  "/usr/local/bin/hyperconverged-cluster-operator"
-]
+files = ["/usr/local/bin/csv-merger"]
+
+[[payload.hyperconverged-cluster-operator-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/usr/local/bin/hyperconverged-cluster-operator"]
 
 [[payload.kubevirt-template-validator-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/sbin/kubevirt-template-validator"
-]
+files = ["/usr/sbin/kubevirt-template-validator"]
 
 [[payload.virt-controller-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/virt-controller"
-]
+files = ["/usr/bin/virt-controller"]
 
 [[payload.ovs-cni-plugin-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/marker",
-  "/ovs",
-  "/ovs-mirror-consumer",
-  "/ovs-mirror-producer"
-]
+files = ["/marker"]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/ovs"]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/ovs-mirror-consumer"]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/ovs-mirror-producer"]
 
 [[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/kubevirt-tekton-tasks.test"
-]
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]

--- a/dist/releases/4.15/config.toml
+++ b/dist/releases/4.15/config.toml
@@ -170,3 +170,268 @@ files = [
 [[payload.multicluster-engine-hypershift-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
+
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/cdi-containerimage-server",
+  "/usr/local/bin/disk-uploader",
+  "/usr/local/bin/kubevirt-tekton-tasks.test",
+  "/usr/bin/ssp-operator.test",
+  "/usr/bin/tekton-tasks-operator.test"
+]
+
+[[payload.virt-handler-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.virt-launcher-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/cdi-containerimage-server"
+]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = [
+  "/usr/bin/cdi-containerimage-server"
+]
+
+[[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-ssp-operator-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/ssp-operator.test"
+]
+
+[[payload.kubevirt-tekton-tasks-copy-template-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-tekton-tasks-operator-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/tekton-tasks-operator.test"
+]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/local/bin/disk-uploader",
+  "/usr/local/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-ssp-operator-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/ssp-operator.test"
+]
+
+[[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/tekton-tasks-operator.test"
+]
+
+[[payload.kubevirt-tekton-tasks-operator-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/tekton-tasks-operator.test"
+]
+
+[[payload.virt-handler-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.virt-cdi-importer-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/cdi-containerimage-server"
+]
+
+[[payload.virt-launcher-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.hyperconverged-cluster-webhook-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/hyperconverged-cluster-webhook"
+]
+
+[[payload.cluster-network-addons-operator-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/cluster-network-addons-operator",
+  "/manifest-templator"
+]
+
+[[payload.bridge-marker-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/bridge-marker"
+]
+
+[[payload.vm-network-latency-checkup-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/checkups/kubevirt-vm-latency"
+]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/modify-data-object"
+]
+
+[[payload.kubemacpool-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/manager"
+]
+
+[[payload.virt-exportserver-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/virt-exportserver"
+]
+
+[[payload.virt-exportproxy-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/virt-exportproxy"
+]
+
+[[payload.kubevirt-tekton-tasks-create-vm-from-template-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/create-vm"
+]
+
+[[payload.kubevirt-tekton-tasks-disk-virt-customize-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/disk-virt-customize"
+]
+
+[[payload.kubevirt-tekton-tasks-wait-for-vmi-status-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/wait-for-vmi-status"
+]
+
+[[payload.cnv-must-gather-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/bin/vmConvertor"
+]
+
+[[payload.cnv-containernetworking-plugins-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/src/github.com/containernetworking/plugins/bin/bridge",
+  "/usr/src/github.com/containernetworking/plugins/bin/tuning"
+]
+
+[[payload.kubevirt-tekton-tasks-cleanup-vm-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/execute-in-vm"
+]
+
+[[payload.virt-api-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/virt-api"
+]
+
+[[payload.virt-operator-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/csv-generator",
+  "/usr/bin/virt-operator"
+]
+
+[[payload.kubevirt-tekton-tasks-disk-virt-sysprep-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/disk-virt-sysprep"
+]
+
+[[payload.ovs-cni-marker-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/src/ovs-cni/bin/ovs-marker"
+]
+
+[[payload.kubevirt-tekton-tasks-modify-vm-template-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/modify-vm-template"
+]
+
+[[payload.hyperconverged-cluster-operator-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/csv-merger",
+  "/usr/local/bin/hyperconverged-cluster-operator"
+]
+
+[[payload.kubevirt-template-validator-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/sbin/kubevirt-template-validator"
+]
+
+[[payload.virt-controller-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/virt-controller"
+]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/marker",
+  "/ovs",
+  "/ovs-mirror-consumer",
+  "/ovs-mirror-producer"
+]
+
+[[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/tekton-tasks-operator.test"
+]

--- a/dist/releases/4.15/config.toml
+++ b/dist/releases/4.15/config.toml
@@ -391,3 +391,7 @@ files = ["/usr/bin/tekton-tasks-operator.test"]
 [[payload.hco-bundle-registry-container.ignore]]
 error = "ErrGoMissingSymbols"
 files = ["/usr/local/bin/disk-uploader"]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/local/bin/disk-uploader"]

--- a/dist/releases/4.15/config.toml
+++ b/dist/releases/4.15/config.toml
@@ -387,3 +387,7 @@ files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 [[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = ["/usr/bin/tekton-tasks-operator.test"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/local/bin/disk-uploader"]

--- a/dist/releases/4.15/config.toml
+++ b/dist/releases/4.15/config.toml
@@ -395,3 +395,7 @@ files = ["/usr/local/bin/disk-uploader"]
 [[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
 error = "ErrGoMissingSymbols"
 files = ["/usr/local/bin/disk-uploader"]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/local/bin/disk-uploader"]

--- a/dist/releases/4.16/config.toml
+++ b/dist/releases/4.16/config.toml
@@ -676,3 +676,6 @@ files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 error = "ErrGoNotCgoEnabled"
 files = ["/usr/bin/tekton-tasks-operator.test"]
 
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/local/bin/disk-uploader"]

--- a/dist/releases/4.16/config.toml
+++ b/dist/releases/4.16/config.toml
@@ -459,3 +459,267 @@ files = ["/tools/opm-rhel8"]
 [[payload.multicluster-engine-hypershift-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/cdi-containerimage-server",
+  "/usr/local/bin/disk-uploader",
+  "/usr/local/bin/kubevirt-tekton-tasks.test",
+  "/usr/bin/ssp-operator.test",
+  "/usr/bin/tekton-tasks-operator.test"
+]
+
+[[payload.virt-handler-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.virt-launcher-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/cdi-containerimage-server"
+]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = [
+  "/usr/bin/cdi-containerimage-server"
+]
+
+[[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-ssp-operator-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/ssp-operator.test"
+]
+
+[[payload.kubevirt-tekton-tasks-copy-template-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-tekton-tasks-operator-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/tekton-tasks-operator.test"
+]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/local/bin/disk-uploader",
+  "/usr/local/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-ssp-operator-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/ssp-operator.test"
+]
+
+[[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/tekton-tasks-operator.test"
+]
+
+[[payload.kubevirt-tekton-tasks-operator-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/tekton-tasks-operator.test"
+]
+
+[[payload.virt-handler-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.virt-cdi-importer-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/cdi-containerimage-server"
+]
+
+[[payload.virt-launcher-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.hyperconverged-cluster-webhook-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/hyperconverged-cluster-webhook"
+]
+
+[[payload.cluster-network-addons-operator-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/cluster-network-addons-operator",
+  "/manifest-templator"
+]
+
+[[payload.bridge-marker-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/bridge-marker"
+]
+
+[[payload.vm-network-latency-checkup-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/checkups/kubevirt-vm-latency"
+]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/modify-data-object"
+]
+
+[[payload.kubemacpool-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/manager"
+]
+
+[[payload.virt-exportserver-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/virt-exportserver"
+]
+
+[[payload.virt-exportproxy-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/virt-exportproxy"
+]
+
+[[payload.kubevirt-tekton-tasks-create-vm-from-template-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/create-vm"
+]
+
+[[payload.kubevirt-tekton-tasks-disk-virt-customize-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/disk-virt-customize"
+]
+
+[[payload.kubevirt-tekton-tasks-wait-for-vmi-status-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/wait-for-vmi-status"
+]
+
+[[payload.cnv-must-gather-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/bin/vmConvertor"
+]
+
+[[payload.cnv-containernetworking-plugins-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/src/github.com/containernetworking/plugins/bin/bridge",
+  "/usr/src/github.com/containernetworking/plugins/bin/tuning"
+]
+
+[[payload.kubevirt-tekton-tasks-cleanup-vm-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/execute-in-vm"
+]
+
+[[payload.virt-api-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/virt-api"
+]
+
+[[payload.virt-operator-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/csv-generator",
+  "/usr/bin/virt-operator"
+]
+
+[[payload.kubevirt-tekton-tasks-disk-virt-sysprep-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/disk-virt-sysprep"
+]
+
+[[payload.ovs-cni-marker-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/src/ovs-cni/bin/ovs-marker"
+]
+
+[[payload.kubevirt-tekton-tasks-modify-vm-template-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/modify-vm-template"
+]
+
+[[payload.hyperconverged-cluster-operator-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/csv-merger",
+  "/usr/local/bin/hyperconverged-cluster-operator"
+]
+
+[[payload.kubevirt-template-validator-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/sbin/kubevirt-template-validator"
+]
+
+[[payload.virt-controller-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/virt-controller"
+]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/marker",
+  "/ovs",
+  "/ovs-mirror-consumer",
+  "/ovs-mirror-producer"
+]
+
+[[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/tekton-tasks-operator.test"
+]

--- a/dist/releases/4.16/config.toml
+++ b/dist/releases/4.16/config.toml
@@ -679,3 +679,7 @@ files = ["/usr/bin/tekton-tasks-operator.test"]
 [[payload.hco-bundle-registry-container.ignore]]
 error = "ErrGoMissingSymbols"
 files = ["/usr/local/bin/disk-uploader"]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/local/bin/disk-uploader"]

--- a/dist/releases/4.16/config.toml
+++ b/dist/releases/4.16/config.toml
@@ -462,264 +462,217 @@ files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
 
 [[payload.hco-bundle-registry-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.hco-bundle-registry-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/cdi-containerimage-server",
-  "/usr/local/bin/disk-uploader",
-  "/usr/local/bin/kubevirt-tekton-tasks.test",
-  "/usr/bin/ssp-operator.test",
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/local/bin/disk-uploader"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/local/bin/kubevirt-tekton-tasks.test"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/ssp-operator.test"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.virt-handler-rhel9-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.virt-launcher-rhel9-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/cdi-containerimage-server"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
 
 [[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoMissingSymbols"
-files = [
-  "/usr/bin/cdi-containerimage-server"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
 
 [[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/kubevirt-tekton-tasks.test"
-]
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-ssp-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/ssp-operator.test"
-]
+files = ["/usr/bin/ssp-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-copy-template-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/kubevirt-tekton-tasks.test"
-]
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/local/bin/disk-uploader",
-  "/usr/local/bin/kubevirt-tekton-tasks.test"
-]
+files = ["/usr/local/bin/disk-uploader"]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/local/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-ssp-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/ssp-operator.test"
-]
+files = ["/usr/bin/ssp-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.virt-handler-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.virt-cdi-importer-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/cdi-containerimage-server"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
 
 [[payload.virt-launcher-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.hyperconverged-cluster-webhook-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/hyperconverged-cluster-webhook"
-]
+files = ["/usr/local/bin/hyperconverged-cluster-webhook"]
 
 [[payload.cluster-network-addons-operator-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/cluster-network-addons-operator",
-  "/manifest-templator"
-]
+files = ["/cluster-network-addons-operator"]
+
+[[payload.cluster-network-addons-operator-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/manifest-templator"]
 
 [[payload.bridge-marker-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/bridge-marker"
-]
+files = ["/bridge-marker"]
 
 [[payload.vm-network-latency-checkup-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/checkups/kubevirt-vm-latency"
-]
+files = ["/checkups/kubevirt-vm-latency"]
 
 [[payload.kubevirt-tekton-tasks-create-datavolume-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/modify-data-object"
-]
+files = ["/usr/local/bin/modify-data-object"]
 
 [[payload.kubemacpool-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/manager"
-]
+files = ["/manager"]
 
 [[payload.virt-exportserver-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/virt-exportserver"
-]
+files = ["/usr/bin/virt-exportserver"]
 
 [[payload.virt-exportproxy-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/virt-exportproxy"
-]
+files = ["/usr/bin/virt-exportproxy"]
 
 [[payload.kubevirt-tekton-tasks-create-vm-from-template-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/create-vm"
-]
+files = ["/usr/local/bin/create-vm"]
 
 [[payload.kubevirt-tekton-tasks-disk-virt-customize-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/disk-virt-customize"
-]
+files = ["/usr/local/bin/disk-virt-customize"]
 
 [[payload.kubevirt-tekton-tasks-wait-for-vmi-status-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/wait-for-vmi-status"
-]
+files = ["/usr/local/bin/wait-for-vmi-status"]
 
 [[payload.cnv-must-gather-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/bin/vmConvertor"
-]
+files = ["/usr/bin/vmConvertor"]
 
 [[payload.cnv-containernetworking-plugins-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/src/github.com/containernetworking/plugins/bin/bridge",
-  "/usr/src/github.com/containernetworking/plugins/bin/tuning"
-]
+files = ["/usr/src/github.com/containernetworking/plugins/bin/bridge"]
+
+[[payload.cnv-containernetworking-plugins-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/usr/src/github.com/containernetworking/plugins/bin/tuning"]
 
 [[payload.kubevirt-tekton-tasks-cleanup-vm-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/execute-in-vm"
-]
+files = ["/usr/local/bin/execute-in-vm"]
 
 [[payload.virt-api-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/virt-api"
-]
+files = ["/usr/bin/virt-api"]
 
 [[payload.virt-operator-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/csv-generator",
-  "/usr/bin/virt-operator"
-]
+files = ["/usr/bin/csv-generator"]
+
+[[payload.virt-operator-container.ignore]]
+error = "ErrGoMissingTag"
+files = ["/usr/bin/virt-operator"]
 
 [[payload.kubevirt-tekton-tasks-disk-virt-sysprep-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/disk-virt-sysprep"
-]
+files = ["/usr/local/bin/disk-virt-sysprep"]
 
 [[payload.ovs-cni-marker-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/src/ovs-cni/bin/ovs-marker"
-]
+files = ["/usr/src/ovs-cni/bin/ovs-marker"]
 
 [[payload.kubevirt-tekton-tasks-modify-vm-template-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/modify-vm-template"
-]
+files = ["/usr/local/bin/modify-vm-template"]
 
 [[payload.hyperconverged-cluster-operator-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/csv-merger",
-  "/usr/local/bin/hyperconverged-cluster-operator"
-]
+files = ["/usr/local/bin/csv-merger"]
+
+[[payload.hyperconverged-cluster-operator-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/usr/local/bin/hyperconverged-cluster-operator"]
 
 [[payload.kubevirt-template-validator-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/sbin/kubevirt-template-validator"
-]
+files = ["/usr/sbin/kubevirt-template-validator"]
 
 [[payload.virt-controller-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/virt-controller"
-]
+files = ["/usr/bin/virt-controller"]
 
 [[payload.ovs-cni-plugin-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/marker",
-  "/ovs",
-  "/ovs-mirror-consumer",
-  "/ovs-mirror-producer"
-]
+files = ["/marker"]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/ovs"]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/ovs-mirror-consumer"]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/ovs-mirror-producer"]
 
 [[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/kubevirt-tekton-tasks.test"
-]
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]
+

--- a/dist/releases/4.16/config.toml
+++ b/dist/releases/4.16/config.toml
@@ -683,3 +683,7 @@ files = ["/usr/local/bin/disk-uploader"]
 [[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
 error = "ErrGoMissingSymbols"
 files = ["/usr/local/bin/disk-uploader"]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/local/bin/disk-uploader"]

--- a/dist/releases/4.17/config.toml
+++ b/dist/releases/4.17/config.toml
@@ -669,3 +669,7 @@ files = ["/usr/bin/tekton-tasks-operator.test"]
 [[payload.hco-bundle-registry-container.ignore]]
 error = "ErrGoMissingSymbols"
 files = ["/usr/local/bin/disk-uploader"]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/local/bin/disk-uploader"]

--- a/dist/releases/4.17/config.toml
+++ b/dist/releases/4.17/config.toml
@@ -452,264 +452,216 @@ files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
 
 [[payload.hco-bundle-registry-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.hco-bundle-registry-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/cdi-containerimage-server",
-  "/usr/local/bin/disk-uploader",
-  "/usr/local/bin/kubevirt-tekton-tasks.test",
-  "/usr/bin/ssp-operator.test",
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/local/bin/disk-uploader"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/local/bin/kubevirt-tekton-tasks.test"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/ssp-operator.test"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.virt-handler-rhel9-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.virt-launcher-rhel9-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/cdi-containerimage-server"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
 
 [[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoMissingSymbols"
-files = [
-  "/usr/bin/cdi-containerimage-server"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
 
 [[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/kubevirt-tekton-tasks.test"
-]
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-ssp-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/ssp-operator.test"
-]
+files = ["/usr/bin/ssp-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-copy-template-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/kubevirt-tekton-tasks.test"
-]
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/local/bin/disk-uploader",
-  "/usr/local/bin/kubevirt-tekton-tasks.test"
-]
+files = ["/usr/local/bin/disk-uploader"]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/local/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-ssp-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/ssp-operator.test"
-]
+files = ["/usr/bin/ssp-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.virt-handler-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.virt-cdi-importer-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/cdi-containerimage-server"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
 
 [[payload.virt-launcher-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.hyperconverged-cluster-webhook-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/hyperconverged-cluster-webhook"
-]
+files = ["/usr/local/bin/hyperconverged-cluster-webhook"]
 
 [[payload.cluster-network-addons-operator-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/cluster-network-addons-operator",
-  "/manifest-templator"
-]
+files = ["/cluster-network-addons-operator"]
+
+[[payload.cluster-network-addons-operator-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/manifest-templator"]
 
 [[payload.bridge-marker-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/bridge-marker"
-]
+files = ["/bridge-marker"]
 
 [[payload.vm-network-latency-checkup-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/checkups/kubevirt-vm-latency"
-]
+files = ["/checkups/kubevirt-vm-latency"]
 
 [[payload.kubevirt-tekton-tasks-create-datavolume-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/modify-data-object"
-]
+files = ["/usr/local/bin/modify-data-object"]
 
 [[payload.kubemacpool-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/manager"
-]
+files = ["/manager"]
 
 [[payload.virt-exportserver-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/virt-exportserver"
-]
+files = ["/usr/bin/virt-exportserver"]
 
 [[payload.virt-exportproxy-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/virt-exportproxy"
-]
+files = ["/usr/bin/virt-exportproxy"]
 
 [[payload.kubevirt-tekton-tasks-create-vm-from-template-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/create-vm"
-]
+files = ["/usr/local/bin/create-vm"]
 
 [[payload.kubevirt-tekton-tasks-disk-virt-customize-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/disk-virt-customize"
-]
+files = ["/usr/local/bin/disk-virt-customize"]
 
 [[payload.kubevirt-tekton-tasks-wait-for-vmi-status-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/wait-for-vmi-status"
-]
+files = ["/usr/local/bin/wait-for-vmi-status"]
 
 [[payload.cnv-must-gather-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/bin/vmConvertor"
-]
+files = ["/usr/bin/vmConvertor"]
 
 [[payload.cnv-containernetworking-plugins-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/src/github.com/containernetworking/plugins/bin/bridge",
-  "/usr/src/github.com/containernetworking/plugins/bin/tuning"
-]
+files = ["/usr/src/github.com/containernetworking/plugins/bin/bridge"]
+
+[[payload.cnv-containernetworking-plugins-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/usr/src/github.com/containernetworking/plugins/bin/tuning"]
 
 [[payload.kubevirt-tekton-tasks-cleanup-vm-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/execute-in-vm"
-]
+files = ["/usr/local/bin/execute-in-vm"]
 
 [[payload.virt-api-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/virt-api"
-]
+files = ["/usr/bin/virt-api"]
 
 [[payload.virt-operator-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/csv-generator",
-  "/usr/bin/virt-operator"
-]
+files = ["/usr/bin/csv-generator"]
+
+[[payload.virt-operator-container.ignore]]
+error = "ErrGoMissingTag"
+files = ["/usr/bin/virt-operator"]
 
 [[payload.kubevirt-tekton-tasks-disk-virt-sysprep-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/disk-virt-sysprep"
-]
+files = ["/usr/local/bin/disk-virt-sysprep"]
 
 [[payload.ovs-cni-marker-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/src/ovs-cni/bin/ovs-marker"
-]
+files = ["/usr/src/ovs-cni/bin/ovs-marker"]
 
 [[payload.kubevirt-tekton-tasks-modify-vm-template-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/modify-vm-template"
-]
+files = ["/usr/local/bin/modify-vm-template"]
 
 [[payload.hyperconverged-cluster-operator-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/csv-merger",
-  "/usr/local/bin/hyperconverged-cluster-operator"
-]
+files = ["/usr/local/bin/csv-merger"]
+
+[[payload.hyperconverged-cluster-operator-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/usr/local/bin/hyperconverged-cluster-operator"]
 
 [[payload.kubevirt-template-validator-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/sbin/kubevirt-template-validator"
-]
+files = ["/usr/sbin/kubevirt-template-validator"]
 
 [[payload.virt-controller-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/virt-controller"
-]
+files = ["/usr/bin/virt-controller"]
 
 [[payload.ovs-cni-plugin-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/marker",
-  "/ovs",
-  "/ovs-mirror-consumer",
-  "/ovs-mirror-producer"
-]
+files = ["/marker"]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/ovs"]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/ovs-mirror-consumer"]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/ovs-mirror-producer"]
 
 [[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/kubevirt-tekton-tasks.test"
-]
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]

--- a/dist/releases/4.17/config.toml
+++ b/dist/releases/4.17/config.toml
@@ -665,3 +665,7 @@ files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 [[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = ["/usr/bin/tekton-tasks-operator.test"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/local/bin/disk-uploader"]

--- a/dist/releases/4.17/config.toml
+++ b/dist/releases/4.17/config.toml
@@ -449,3 +449,267 @@ files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
 [[payload.multicluster-engine-hypershift-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/cdi-containerimage-server",
+  "/usr/local/bin/disk-uploader",
+  "/usr/local/bin/kubevirt-tekton-tasks.test",
+  "/usr/bin/ssp-operator.test",
+  "/usr/bin/tekton-tasks-operator.test"
+]
+
+[[payload.virt-handler-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.virt-launcher-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/cdi-containerimage-server"
+]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = [
+  "/usr/bin/cdi-containerimage-server"
+]
+
+[[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-ssp-operator-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/ssp-operator.test"
+]
+
+[[payload.kubevirt-tekton-tasks-copy-template-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-tekton-tasks-operator-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/tekton-tasks-operator.test"
+]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/local/bin/disk-uploader",
+  "/usr/local/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-ssp-operator-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/ssp-operator.test"
+]
+
+[[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/tekton-tasks-operator.test"
+]
+
+[[payload.kubevirt-tekton-tasks-operator-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/tekton-tasks-operator.test"
+]
+
+[[payload.virt-handler-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.virt-cdi-importer-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/cdi-containerimage-server"
+]
+
+[[payload.virt-launcher-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.hyperconverged-cluster-webhook-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/hyperconverged-cluster-webhook"
+]
+
+[[payload.cluster-network-addons-operator-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/cluster-network-addons-operator",
+  "/manifest-templator"
+]
+
+[[payload.bridge-marker-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/bridge-marker"
+]
+
+[[payload.vm-network-latency-checkup-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/checkups/kubevirt-vm-latency"
+]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/modify-data-object"
+]
+
+[[payload.kubemacpool-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/manager"
+]
+
+[[payload.virt-exportserver-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/virt-exportserver"
+]
+
+[[payload.virt-exportproxy-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/virt-exportproxy"
+]
+
+[[payload.kubevirt-tekton-tasks-create-vm-from-template-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/create-vm"
+]
+
+[[payload.kubevirt-tekton-tasks-disk-virt-customize-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/disk-virt-customize"
+]
+
+[[payload.kubevirt-tekton-tasks-wait-for-vmi-status-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/wait-for-vmi-status"
+]
+
+[[payload.cnv-must-gather-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/bin/vmConvertor"
+]
+
+[[payload.cnv-containernetworking-plugins-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/src/github.com/containernetworking/plugins/bin/bridge",
+  "/usr/src/github.com/containernetworking/plugins/bin/tuning"
+]
+
+[[payload.kubevirt-tekton-tasks-cleanup-vm-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/execute-in-vm"
+]
+
+[[payload.virt-api-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/virt-api"
+]
+
+[[payload.virt-operator-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/csv-generator",
+  "/usr/bin/virt-operator"
+]
+
+[[payload.kubevirt-tekton-tasks-disk-virt-sysprep-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/disk-virt-sysprep"
+]
+
+[[payload.ovs-cni-marker-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/src/ovs-cni/bin/ovs-marker"
+]
+
+[[payload.kubevirt-tekton-tasks-modify-vm-template-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/modify-vm-template"
+]
+
+[[payload.hyperconverged-cluster-operator-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/csv-merger",
+  "/usr/local/bin/hyperconverged-cluster-operator"
+]
+
+[[payload.kubevirt-template-validator-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/sbin/kubevirt-template-validator"
+]
+
+[[payload.virt-controller-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/virt-controller"
+]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/marker",
+  "/ovs",
+  "/ovs-mirror-consumer",
+  "/ovs-mirror-producer"
+]
+
+[[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/tekton-tasks-operator.test"
+]

--- a/dist/releases/4.17/config.toml
+++ b/dist/releases/4.17/config.toml
@@ -673,3 +673,7 @@ files = ["/usr/local/bin/disk-uploader"]
 [[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
 error = "ErrGoMissingSymbols"
 files = ["/usr/local/bin/disk-uploader"]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/local/bin/disk-uploader"]

--- a/dist/releases/4.18/config.toml
+++ b/dist/releases/4.18/config.toml
@@ -444,63 +444,268 @@ files = ["/unpack"]
 error = "ErrGoNotCgoEnabled"
 files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
 
+
+
 [[payload.hco-bundle-registry-container.ignore]]
 error = "ErrNotDynLinked"
-files = ["/usr/bin/container-disk"]
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/cdi-containerimage-server",
+  "/usr/local/bin/disk-uploader",
+  "/usr/local/bin/kubevirt-tekton-tasks.test",
+  "/usr/bin/ssp-operator.test",
+  "/usr/bin/tekton-tasks-operator.test"
+]
 
 [[payload.virt-handler-rhel9-container.ignore]]
 error = "ErrNotDynLinked"
-files = ["/usr/bin/container-disk"]
+files = [
+  "/usr/bin/container-disk"
+]
 
 [[payload.virt-launcher-rhel9-container.ignore]]
 error = "ErrNotDynLinked"
-files = ["/usr/bin/container-disk"]
+files = [
+  "/usr/bin/container-disk"
+]
 
 [[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-"/usr/bin/cdi-containerimage-server"
+  "/usr/bin/cdi-containerimage-server"
+]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = [
+  "/usr/bin/cdi-containerimage-server"
 ]
 
 [[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-"/usr/bin/kubevirt-tekton-tasks.test"
+  "/usr/bin/kubevirt-tekton-tasks.test"
 ]
 
 [[payload.kubevirt-ssp-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-"/usr/bin/ssp-operator.test"
+  "/usr/bin/ssp-operator.test"
 ]
 
 [[payload.kubevirt-tekton-tasks-copy-template-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-"/usr/bin/kubevirt-tekton-tasks.test"
+  "/usr/bin/kubevirt-tekton-tasks.test"
 ]
 
 [[payload.kubevirt-tekton-tasks-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-"/usr/bin/tekton-tasks-operator.test"
+  "/usr/bin/tekton-tasks-operator.test"
 ]
 
 [[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-"/usr/local/bin/disk-uploader",
-"/usr/local/bin/kubevirt-tekton-tasks.test"
+  "/usr/local/bin/disk-uploader",
+  "/usr/local/bin/kubevirt-tekton-tasks.test"
 ]
 
 [[payload.kubevirt-ssp-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-"/usr/bin/ssp-operator.test"
+  "/usr/bin/ssp-operator.test"
 ]
 
 [[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-"/usr/bin/tekton-tasks-operator.test"
+  "/usr/bin/tekton-tasks-operator.test"
+]
+
+[[payload.kubevirt-tekton-tasks-operator-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/tekton-tasks-operator.test"
+]
+
+[[payload.virt-handler-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.virt-cdi-importer-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/cdi-containerimage-server"
+]
+
+[[payload.virt-launcher-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.hyperconverged-cluster-webhook-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/hyperconverged-cluster-webhook"
+]
+
+[[payload.cluster-network-addons-operator-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/cluster-network-addons-operator",
+  "/manifest-templator"
+]
+
+[[payload.bridge-marker-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/bridge-marker"
+]
+
+[[payload.vm-network-latency-checkup-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/checkups/kubevirt-vm-latency"
+]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/modify-data-object"
+]
+
+[[payload.kubemacpool-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/manager"
+]
+
+[[payload.virt-exportserver-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/virt-exportserver"
+]
+
+[[payload.virt-exportproxy-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/virt-exportproxy"
+]
+
+[[payload.kubevirt-tekton-tasks-create-vm-from-template-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/create-vm"
+]
+
+[[payload.kubevirt-tekton-tasks-disk-virt-customize-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/disk-virt-customize"
+]
+
+[[payload.kubevirt-tekton-tasks-wait-for-vmi-status-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/wait-for-vmi-status"
+]
+
+[[payload.cnv-must-gather-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/bin/vmConvertor"
+]
+
+[[payload.cnv-containernetworking-plugins-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/src/github.com/containernetworking/plugins/bin/bridge",
+  "/usr/src/github.com/containernetworking/plugins/bin/tuning"
+]
+
+[[payload.kubevirt-tekton-tasks-cleanup-vm-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/execute-in-vm"
+]
+
+[[payload.virt-api-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/virt-api"
+]
+
+[[payload.virt-operator-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/csv-generator",
+  "/usr/bin/virt-operator"
+]
+
+[[payload.kubevirt-tekton-tasks-disk-virt-sysprep-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/disk-virt-sysprep"
+]
+
+[[payload.ovs-cni-marker-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/src/ovs-cni/bin/ovs-marker"
+]
+
+[[payload.kubevirt-tekton-tasks-modify-vm-template-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/modify-vm-template"
+]
+
+[[payload.hyperconverged-cluster-operator-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/csv-merger",
+  "/usr/local/bin/hyperconverged-cluster-operator"
+]
+
+[[payload.kubevirt-template-validator-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/sbin/kubevirt-template-validator"
+]
+
+[[payload.virt-controller-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/virt-controller"
+]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/marker",
+  "/ovs",
+  "/ovs-mirror-consumer",
+  "/ovs-mirror-producer"
+]
+
+[[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/tekton-tasks-operator.test"
 ]

--- a/dist/releases/4.18/config.toml
+++ b/dist/releases/4.18/config.toml
@@ -665,3 +665,7 @@ files = ["/usr/bin/tekton-tasks-operator.test"]
 [[payload.hco-bundle-registry-container.ignore]]
 error = "ErrGoMissingSymbols"
 files = ["/usr/local/bin/disk-uploader"]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/local/bin/disk-uploader"]

--- a/dist/releases/4.18/config.toml
+++ b/dist/releases/4.18/config.toml
@@ -661,3 +661,7 @@ files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 [[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = ["/usr/bin/tekton-tasks-operator.test"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/local/bin/disk-uploader"]

--- a/dist/releases/4.18/config.toml
+++ b/dist/releases/4.18/config.toml
@@ -669,3 +669,7 @@ files = ["/usr/local/bin/disk-uploader"]
 [[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
 error = "ErrGoMissingSymbols"
 files = ["/usr/local/bin/disk-uploader"]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/local/bin/disk-uploader"]

--- a/dist/releases/4.18/config.toml
+++ b/dist/releases/4.18/config.toml
@@ -448,264 +448,216 @@ files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
 
 [[payload.hco-bundle-registry-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.hco-bundle-registry-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/cdi-containerimage-server",
-  "/usr/local/bin/disk-uploader",
-  "/usr/local/bin/kubevirt-tekton-tasks.test",
-  "/usr/bin/ssp-operator.test",
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/local/bin/disk-uploader"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/local/bin/kubevirt-tekton-tasks.test"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/ssp-operator.test"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.virt-handler-rhel9-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.virt-launcher-rhel9-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/cdi-containerimage-server"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
 
 [[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoMissingSymbols"
-files = [
-  "/usr/bin/cdi-containerimage-server"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
 
 [[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/kubevirt-tekton-tasks.test"
-]
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-ssp-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/ssp-operator.test"
-]
+files = ["/usr/bin/ssp-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-copy-template-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/kubevirt-tekton-tasks.test"
-]
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/local/bin/disk-uploader",
-  "/usr/local/bin/kubevirt-tekton-tasks.test"
-]
+files = ["/usr/local/bin/disk-uploader"]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/local/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-ssp-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/ssp-operator.test"
-]
+files = ["/usr/bin/ssp-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.virt-handler-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.virt-cdi-importer-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/cdi-containerimage-server"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
 
 [[payload.virt-launcher-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.hyperconverged-cluster-webhook-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/hyperconverged-cluster-webhook"
-]
+files = ["/usr/local/bin/hyperconverged-cluster-webhook"]
 
 [[payload.cluster-network-addons-operator-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/cluster-network-addons-operator",
-  "/manifest-templator"
-]
+files = ["/cluster-network-addons-operator"]
+
+[[payload.cluster-network-addons-operator-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/manifest-templator"]
 
 [[payload.bridge-marker-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/bridge-marker"
-]
+files = ["/bridge-marker"]
 
 [[payload.vm-network-latency-checkup-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/checkups/kubevirt-vm-latency"
-]
+files = ["/checkups/kubevirt-vm-latency"]
 
 [[payload.kubevirt-tekton-tasks-create-datavolume-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/modify-data-object"
-]
+files = ["/usr/local/bin/modify-data-object"]
 
 [[payload.kubemacpool-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/manager"
-]
+files = ["/manager"]
 
 [[payload.virt-exportserver-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/virt-exportserver"
-]
+files = ["/usr/bin/virt-exportserver"]
 
 [[payload.virt-exportproxy-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/virt-exportproxy"
-]
+files = ["/usr/bin/virt-exportproxy"]
 
 [[payload.kubevirt-tekton-tasks-create-vm-from-template-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/create-vm"
-]
+files = ["/usr/local/bin/create-vm"]
 
 [[payload.kubevirt-tekton-tasks-disk-virt-customize-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/disk-virt-customize"
-]
+files = ["/usr/local/bin/disk-virt-customize"]
 
 [[payload.kubevirt-tekton-tasks-wait-for-vmi-status-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/wait-for-vmi-status"
-]
+files = ["/usr/local/bin/wait-for-vmi-status"]
 
 [[payload.cnv-must-gather-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/bin/vmConvertor"
-]
+files = ["/usr/bin/vmConvertor"]
 
 [[payload.cnv-containernetworking-plugins-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/src/github.com/containernetworking/plugins/bin/bridge",
-  "/usr/src/github.com/containernetworking/plugins/bin/tuning"
-]
+files = ["/usr/src/github.com/containernetworking/plugins/bin/bridge"]
+
+[[payload.cnv-containernetworking-plugins-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/usr/src/github.com/containernetworking/plugins/bin/tuning"]
 
 [[payload.kubevirt-tekton-tasks-cleanup-vm-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/execute-in-vm"
-]
+files = ["/usr/local/bin/execute-in-vm"]
 
 [[payload.virt-api-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/virt-api"
-]
+files = ["/usr/bin/virt-api"]
 
 [[payload.virt-operator-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/csv-generator",
-  "/usr/bin/virt-operator"
-]
+files = ["/usr/bin/csv-generator"]
+
+[[payload.virt-operator-container.ignore]]
+error = "ErrGoMissingTag"
+files = ["/usr/bin/virt-operator"]
 
 [[payload.kubevirt-tekton-tasks-disk-virt-sysprep-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/disk-virt-sysprep"
-]
+files = ["/usr/local/bin/disk-virt-sysprep"]
 
 [[payload.ovs-cni-marker-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/src/ovs-cni/bin/ovs-marker"
-]
+files = ["/usr/src/ovs-cni/bin/ovs-marker"]
 
 [[payload.kubevirt-tekton-tasks-modify-vm-template-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/modify-vm-template"
-]
+files = ["/usr/local/bin/modify-vm-template"]
 
 [[payload.hyperconverged-cluster-operator-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/csv-merger",
-  "/usr/local/bin/hyperconverged-cluster-operator"
-]
+files = ["/usr/local/bin/csv-merger"]
+
+[[payload.hyperconverged-cluster-operator-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/usr/local/bin/hyperconverged-cluster-operator"]
 
 [[payload.kubevirt-template-validator-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/sbin/kubevirt-template-validator"
-]
+files = ["/usr/sbin/kubevirt-template-validator"]
 
 [[payload.virt-controller-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/virt-controller"
-]
+files = ["/usr/bin/virt-controller"]
 
 [[payload.ovs-cni-plugin-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/marker",
-  "/ovs",
-  "/ovs-mirror-consumer",
-  "/ovs-mirror-producer"
-]
+files = ["/marker"]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/ovs"]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/ovs-mirror-consumer"]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/ovs-mirror-producer"]
 
 [[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/kubevirt-tekton-tasks.test"
-]
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]

--- a/dist/releases/4.19/config.toml
+++ b/dist/releases/4.19/config.toml
@@ -665,3 +665,7 @@ files = ["/usr/bin/tekton-tasks-operator.test"]
 [[payload.hco-bundle-registry-container.ignore]]
 error = "ErrGoMissingSymbols"
 files = ["/usr/local/bin/disk-uploader"]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/local/bin/disk-uploader"]

--- a/dist/releases/4.19/config.toml
+++ b/dist/releases/4.19/config.toml
@@ -661,3 +661,7 @@ files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 [[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = ["/usr/bin/tekton-tasks-operator.test"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/local/bin/disk-uploader"]

--- a/dist/releases/4.19/config.toml
+++ b/dist/releases/4.19/config.toml
@@ -444,9 +444,13 @@ files = ["/unpack"]
 error = "ErrGoNotCgoEnabled"
 files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
 
+
+
 [[payload.hco-bundle-registry-container.ignore]]
 error = "ErrNotDynLinked"
-files = ["/usr/bin/container-disk"]
+files = [
+  "/usr/bin/container-disk"
+]
 
 [[payload.hco-bundle-registry-container.ignore]]
 error = "ErrGoNotCgoEnabled"
@@ -458,64 +462,250 @@ files = [
   "/usr/bin/tekton-tasks-operator.test"
 ]
 
-[[payload.hco-bundle-registry-container.ignore]]
-error = "ErrNotDynLinked"
-files = ["/usr/bin/container-disk"]
-
-
 [[payload.virt-handler-rhel9-container.ignore]]
 error = "ErrNotDynLinked"
-files = ["/usr/bin/container-disk"]
+files = [
+  "/usr/bin/container-disk"
+]
 
 [[payload.virt-launcher-rhel9-container.ignore]]
 error = "ErrNotDynLinked"
-files = ["/usr/bin/container-disk"]
+files = [
+  "/usr/bin/container-disk"
+]
 
 [[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-"/usr/bin/cdi-containerimage-server"
+  "/usr/bin/cdi-containerimage-server"
+]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = [
+  "/usr/bin/cdi-containerimage-server"
 ]
 
 [[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-"/usr/bin/kubevirt-tekton-tasks.test"
+  "/usr/bin/kubevirt-tekton-tasks.test"
 ]
 
 [[payload.kubevirt-ssp-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-"/usr/bin/ssp-operator.test"
+  "/usr/bin/ssp-operator.test"
 ]
 
 [[payload.kubevirt-tekton-tasks-copy-template-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-"/usr/bin/kubevirt-tekton-tasks.test"
+  "/usr/bin/kubevirt-tekton-tasks.test"
 ]
 
 [[payload.kubevirt-tekton-tasks-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-"/usr/bin/tekton-tasks-operator.test"
+  "/usr/bin/tekton-tasks-operator.test"
 ]
 
 [[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-"/usr/local/bin/disk-uploader",
-"/usr/local/bin/kubevirt-tekton-tasks.test"
+  "/usr/local/bin/disk-uploader",
+  "/usr/local/bin/kubevirt-tekton-tasks.test"
 ]
 
 [[payload.kubevirt-ssp-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-"/usr/bin/ssp-operator.test"
+  "/usr/bin/ssp-operator.test"
 ]
 
 [[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-"/usr/bin/tekton-tasks-operator.test"
+  "/usr/bin/tekton-tasks-operator.test"
+]
+
+[[payload.kubevirt-tekton-tasks-operator-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/tekton-tasks-operator.test"
+]
+
+[[payload.virt-handler-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.virt-cdi-importer-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/cdi-containerimage-server"
+]
+
+[[payload.virt-launcher-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/container-disk"
+]
+
+[[payload.hyperconverged-cluster-webhook-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/hyperconverged-cluster-webhook"
+]
+
+[[payload.cluster-network-addons-operator-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/cluster-network-addons-operator",
+  "/manifest-templator"
+]
+
+[[payload.bridge-marker-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/bridge-marker"
+]
+
+[[payload.vm-network-latency-checkup-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/checkups/kubevirt-vm-latency"
+]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/modify-data-object"
+]
+
+[[payload.kubemacpool-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/manager"
+]
+
+[[payload.virt-exportserver-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/virt-exportserver"
+]
+
+[[payload.virt-exportproxy-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/virt-exportproxy"
+]
+
+[[payload.kubevirt-tekton-tasks-create-vm-from-template-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/create-vm"
+]
+
+[[payload.kubevirt-tekton-tasks-disk-virt-customize-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/disk-virt-customize"
+]
+
+[[payload.kubevirt-tekton-tasks-wait-for-vmi-status-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/wait-for-vmi-status"
+]
+
+[[payload.cnv-must-gather-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/bin/vmConvertor"
+]
+
+[[payload.cnv-containernetworking-plugins-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/src/github.com/containernetworking/plugins/bin/bridge",
+  "/usr/src/github.com/containernetworking/plugins/bin/tuning"
+]
+
+[[payload.kubevirt-tekton-tasks-cleanup-vm-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/execute-in-vm"
+]
+
+[[payload.virt-api-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/virt-api"
+]
+
+[[payload.virt-operator-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/csv-generator",
+  "/usr/bin/virt-operator"
+]
+
+[[payload.kubevirt-tekton-tasks-disk-virt-sysprep-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/disk-virt-sysprep"
+]
+
+[[payload.ovs-cni-marker-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/src/ovs-cni/bin/ovs-marker"
+]
+
+[[payload.kubevirt-tekton-tasks-modify-vm-template-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/modify-vm-template"
+]
+
+[[payload.hyperconverged-cluster-operator-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/local/bin/csv-merger",
+  "/usr/local/bin/hyperconverged-cluster-operator"
+]
+
+[[payload.kubevirt-template-validator-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/usr/sbin/kubevirt-template-validator"
+]
+
+[[payload.virt-controller-container.ignore]]
+error = "ErrGoMissingTag"
+files = [
+  "/usr/bin/virt-controller"
+]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = [
+  "/marker",
+  "/ovs",
+  "/ovs-mirror-consumer",
+  "/ovs-mirror-producer"
+]
+
+[[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/bin/tekton-tasks-operator.test"
 ]

--- a/dist/releases/4.19/config.toml
+++ b/dist/releases/4.19/config.toml
@@ -669,3 +669,7 @@ files = ["/usr/local/bin/disk-uploader"]
 [[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
 error = "ErrGoMissingSymbols"
 files = ["/usr/local/bin/disk-uploader"]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/local/bin/disk-uploader"]

--- a/dist/releases/4.19/config.toml
+++ b/dist/releases/4.19/config.toml
@@ -448,264 +448,216 @@ files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
 
 [[payload.hco-bundle-registry-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.hco-bundle-registry-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/cdi-containerimage-server",
-  "/usr/local/bin/disk-uploader",
-  "/usr/local/bin/kubevirt-tekton-tasks.test",
-  "/usr/bin/ssp-operator.test",
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/local/bin/disk-uploader"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/local/bin/kubevirt-tekton-tasks.test"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/ssp-operator.test"]
+
+[[payload.hco-bundle-registry-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.virt-handler-rhel9-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.virt-launcher-rhel9-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/cdi-containerimage-server"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
 
 [[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoMissingSymbols"
-files = [
-  "/usr/bin/cdi-containerimage-server"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
 
 [[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/kubevirt-tekton-tasks.test"
-]
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-ssp-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/ssp-operator.test"
-]
+files = ["/usr/bin/ssp-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-copy-template-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/kubevirt-tekton-tasks.test"
-]
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/local/bin/disk-uploader",
-  "/usr/local/bin/kubevirt-tekton-tasks.test"
-]
+files = ["/usr/local/bin/disk-uploader"]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/local/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-ssp-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/ssp-operator.test"
-]
+files = ["/usr/bin/ssp-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]
 
 [[payload.virt-handler-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.virt-cdi-importer-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/cdi-containerimage-server"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
 
 [[payload.virt-launcher-container.ignore]]
 error = "ErrNotDynLinked"
-files = [
-  "/usr/bin/container-disk"
-]
+files = ["/usr/bin/container-disk"]
 
 [[payload.hyperconverged-cluster-webhook-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/hyperconverged-cluster-webhook"
-]
+files = ["/usr/local/bin/hyperconverged-cluster-webhook"]
 
 [[payload.cluster-network-addons-operator-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/cluster-network-addons-operator",
-  "/manifest-templator"
-]
+files = ["/cluster-network-addons-operator"]
+
+[[payload.cluster-network-addons-operator-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/manifest-templator"]
 
 [[payload.bridge-marker-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/bridge-marker"
-]
+files = ["/bridge-marker"]
 
 [[payload.vm-network-latency-checkup-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/checkups/kubevirt-vm-latency"
-]
+files = ["/checkups/kubevirt-vm-latency"]
 
 [[payload.kubevirt-tekton-tasks-create-datavolume-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/modify-data-object"
-]
+files = ["/usr/local/bin/modify-data-object"]
 
 [[payload.kubemacpool-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/manager"
-]
+files = ["/manager"]
 
 [[payload.virt-exportserver-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/virt-exportserver"
-]
+files = ["/usr/bin/virt-exportserver"]
 
 [[payload.virt-exportproxy-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/virt-exportproxy"
-]
+files = ["/usr/bin/virt-exportproxy"]
 
 [[payload.kubevirt-tekton-tasks-create-vm-from-template-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/create-vm"
-]
+files = ["/usr/local/bin/create-vm"]
 
 [[payload.kubevirt-tekton-tasks-disk-virt-customize-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/disk-virt-customize"
-]
+files = ["/usr/local/bin/disk-virt-customize"]
 
 [[payload.kubevirt-tekton-tasks-wait-for-vmi-status-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/wait-for-vmi-status"
-]
+files = ["/usr/local/bin/wait-for-vmi-status"]
 
 [[payload.cnv-must-gather-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/bin/vmConvertor"
-]
+files = ["/usr/bin/vmConvertor"]
 
 [[payload.cnv-containernetworking-plugins-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/src/github.com/containernetworking/plugins/bin/bridge",
-  "/usr/src/github.com/containernetworking/plugins/bin/tuning"
-]
+files = ["/usr/src/github.com/containernetworking/plugins/bin/bridge"]
+
+[[payload.cnv-containernetworking-plugins-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/usr/src/github.com/containernetworking/plugins/bin/tuning"]
 
 [[payload.kubevirt-tekton-tasks-cleanup-vm-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/execute-in-vm"
-]
+files = ["/usr/local/bin/execute-in-vm"]
 
 [[payload.virt-api-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/virt-api"
-]
+files = ["/usr/bin/virt-api"]
 
 [[payload.virt-operator-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/csv-generator",
-  "/usr/bin/virt-operator"
-]
+files = ["/usr/bin/csv-generator"]
+
+[[payload.virt-operator-container.ignore]]
+error = "ErrGoMissingTag"
+files = ["/usr/bin/virt-operator"]
 
 [[payload.kubevirt-tekton-tasks-disk-virt-sysprep-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/disk-virt-sysprep"
-]
+files = ["/usr/local/bin/disk-virt-sysprep"]
 
 [[payload.ovs-cni-marker-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/src/ovs-cni/bin/ovs-marker"
-]
+files = ["/usr/src/ovs-cni/bin/ovs-marker"]
 
 [[payload.kubevirt-tekton-tasks-modify-vm-template-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/modify-vm-template"
-]
+files = ["/usr/local/bin/modify-vm-template"]
 
 [[payload.hyperconverged-cluster-operator-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/local/bin/csv-merger",
-  "/usr/local/bin/hyperconverged-cluster-operator"
-]
+files = ["/usr/local/bin/csv-merger"]
+
+[[payload.hyperconverged-cluster-operator-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/usr/local/bin/hyperconverged-cluster-operator"]
 
 [[payload.kubevirt-template-validator-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/usr/sbin/kubevirt-template-validator"
-]
+files = ["/usr/sbin/kubevirt-template-validator"]
 
 [[payload.virt-controller-container.ignore]]
 error = "ErrGoMissingTag"
-files = [
-  "/usr/bin/virt-controller"
-]
+files = ["/usr/bin/virt-controller"]
 
 [[payload.ovs-cni-plugin-container.ignore]]
 error = "ErrGoNoTags"
-files = [
-  "/marker",
-  "/ovs",
-  "/ovs-mirror-consumer",
-  "/ovs-mirror-producer"
-]
+files = ["/marker"]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/ovs"]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/ovs-mirror-consumer"]
+
+[[payload.ovs-cni-plugin-container.ignore]]
+error = "ErrGoNoTags"
+files = ["/ovs-mirror-producer"]
 
 [[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/kubevirt-tekton-tasks.test"
-]
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-  "/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]


### PR DESCRIPTION
after validating the last update we still saw missing configurations, so we added them and extended to all versions just to be on the safe side, cause we noticed in v4.12 didn't catch the ignores