### PR TITLE
Add FIPS exclusions to CNV

### DIFF
--- a/dist/releases/4.12/config.toml
+++ b/dist/releases/4.12/config.toml
@@ -37,3 +37,39 @@ files = ["/usr/bin/cpb"]
 [[payload.operator-lifecycle-manager-container.ignore]]
 error = "ErrLibcryptoMissing"
 files = ["/usr/bin/cpb"]
+
+[[payload.virt-handler-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/bin/container-disk"]
+
+[[payload.virt-launcher-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/bin/container-disk"]
+
+[[payload.virt-cdi-importer-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.virt-cdi-importer-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.virt-cdi-importer-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.virt-cdi-importer-container.ignore]]
+error = "ErrLibcryptoMissing"
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.kubevirt-tekton-tasks-copy-template-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
+
+[[payload.kubevirt-tekton-tasks-operator-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/tekton-tasks-operator.test"]
+
+[[payload.kubevirt-ssp-operator-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/ssp-operator.test"]

--- a/dist/releases/4.13/config.toml
+++ b/dist/releases/4.13/config.toml
@@ -112,49 +112,75 @@ files = ["/usr/bin/container-disk"]
 
 [[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-"/usr/bin/cdi-containerimage-server"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrLibcryptoMissing"
+files = ["/usr/bin/cdi-containerimage-server"]
 
 [[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-"/usr/bin/kubevirt-tekton-tasks.test"
-]
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
+
+[[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
+
+[[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
+
+[[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
+error = "ErrLibcryptoMissing"
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-ssp-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-"/usr/bin/ssp-operator.test"
-]
-
-[[payload.kubevirt-tekton-tasks-copy-template-container.ignore]]
-error = "ErrGoNotCgoEnabled"
-files = [
-"/usr/bin/kubevirt-tekton-tasks.test"
-]
-
-[[payload.kubevirt-tekton-tasks-operator-container.ignore]]
-error = "ErrGoNotCgoEnabled"
-files = [
-"/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/ssp-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-"/usr/local/bin/disk-uploader",
-"/usr/local/bin/kubevirt-tekton-tasks.test"
+  "/usr/local/bin/disk-uploader",
+  "/usr/local/bin/kubevirt-tekton-tasks.test"
 ]
 
 [[payload.kubevirt-ssp-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-"/usr/bin/ssp-operator.test"
-]
+files = ["/usr/bin/ssp-operator.test"]
+
+[[payload.kubevirt-ssp-operator-rhel9-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/bin/ssp-operator.test"]
+
+[[payload.kubevirt-ssp-operator-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/bin/ssp-operator.test"]
+
+[[payload.kubevirt-ssp-operator-rhel9-container.ignore]]
+error = "ErrLibcryptoMissing"
+files = ["/usr/bin/ssp-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-"/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]
+
+[[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/bin/tekton-tasks-operator.test"]
+
+[[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/bin/tekton-tasks-operator.test"]
+
+[[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
+error = "ErrLibcryptoMissing"
+files = ["/usr/bin/tekton-tasks-operator.test"]

--- a/dist/releases/4.14/config.toml
+++ b/dist/releases/4.14/config.toml
@@ -147,3 +147,51 @@ files = ["/usr/bin/ib-sriov"]
 [[payload.sriov-cni-container.ignore]]
 error = "ErrLibcryptoSoMissing"
 files = ["/usr/bin/rhel8/sriov"]
+
+[[payload.kubevirt-ssp-operator-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/ssp-operator.test"]
+
+[[payload.kubevirt-ssp-operator-rhel9-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/bin/ssp-operator.test"]
+
+[[payload.kubevirt-ssp-operator-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/bin/ssp-operator.test"]
+
+[[payload.kubevirt-ssp-operator-rhel9-container.ignore]]
+error = "ErrLibcryptoMissing"
+files = ["/usr/bin/ssp-operator.test"]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/local/bin/kubevirt-tekton-tasks.test"]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/local/bin/kubevirt-tekton-tasks.test"]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/local/bin/kubevirt-tekton-tasks.test"]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrLibcryptoMissing"
+files = ["/usr/local/bin/kubevirt-tekton-tasks.test"]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrLibcryptoMissing"
+files = ["/usr/bin/cdi-containerimage-server"]

--- a/dist/releases/4.15/config.toml
+++ b/dist/releases/4.15/config.toml
@@ -170,3 +170,19 @@ files = [
 [[payload.multicluster-engine-hypershift-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrLibcryptoMissing"
+files = ["/usr/bin/cdi-containerimage-server"]

--- a/dist/releases/4.16/config.toml
+++ b/dist/releases/4.16/config.toml
@@ -459,3 +459,19 @@ files = ["/tools/opm-rhel8"]
 [[payload.multicluster-engine-hypershift-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrLibcryptoMissing"
+files = ["/usr/bin/cdi-containerimage-server"]

--- a/dist/releases/4.17/config.toml
+++ b/dist/releases/4.17/config.toml
@@ -449,3 +449,47 @@ files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
 [[payload.multicluster-engine-hypershift-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrLibcryptoMissing"
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/usr/local/bin/disk-uploader",
+  "/usr/local/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = [
+  "/usr/local/bin/disk-uploader",
+  "/usr/local/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/local/bin/disk-uploader",
+  "/usr/local/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrLibcryptoMissing"
+files = [
+  "/usr/local/bin/disk-uploader",
+  "/usr/local/bin/kubevirt-tekton-tasks.test"
+]

--- a/dist/releases/4.18/config.toml
+++ b/dist/releases/4.18/config.toml
@@ -458,49 +458,60 @@ files = ["/usr/bin/container-disk"]
 
 [[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-"/usr/bin/cdi-containerimage-server"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrLibcryptoMissing"
+files = ["/usr/bin/cdi-containerimage-server"]
 
 [[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-"/usr/bin/kubevirt-tekton-tasks.test"
-]
-
-[[payload.kubevirt-ssp-operator-container.ignore]]
-error = "ErrGoNotCgoEnabled"
-files = [
-"/usr/bin/ssp-operator.test"
-]
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-tekton-tasks-copy-template-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-"/usr/bin/kubevirt-tekton-tasks.test"
-]
-
-[[payload.kubevirt-tekton-tasks-operator-container.ignore]]
-error = "ErrGoNotCgoEnabled"
-files = [
-"/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-"/usr/local/bin/disk-uploader",
-"/usr/local/bin/kubevirt-tekton-tasks.test"
+  "/usr/local/bin/disk-uploader",
+  "/usr/local/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = [
+  "/usr/local/bin/disk-uploader",
+  "/usr/local/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/local/bin/disk-uploader",
+  "/usr/local/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrLibcryptoMissing"
+files = [
+  "/usr/local/bin/disk-uploader",
+  "/usr/local/bin/kubevirt-tekton-tasks.test"
 ]
 
 [[payload.kubevirt-ssp-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-"/usr/bin/ssp-operator.test"
-]
+files = ["/usr/bin/ssp-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-"/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]

--- a/dist/releases/4.19/config.toml
+++ b/dist/releases/4.19/config.toml
@@ -462,7 +462,6 @@ files = [
 error = "ErrNotDynLinked"
 files = ["/usr/bin/container-disk"]
 
-
 [[payload.virt-handler-rhel9-container.ignore]]
 error = "ErrNotDynLinked"
 files = ["/usr/bin/container-disk"]
@@ -473,49 +472,60 @@ files = ["/usr/bin/container-disk"]
 
 [[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-"/usr/bin/cdi-containerimage-server"
-]
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/bin/cdi-containerimage-server"]
+
+[[payload.virt-cdi-importer-rhel9-container.ignore]]
+error = "ErrLibcryptoMissing"
+files = ["/usr/bin/cdi-containerimage-server"]
 
 [[payload.kubevirt-tekton-tasks-copy-template-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-"/usr/bin/kubevirt-tekton-tasks.test"
-]
-
-[[payload.kubevirt-ssp-operator-container.ignore]]
-error = "ErrGoNotCgoEnabled"
-files = [
-"/usr/bin/ssp-operator.test"
-]
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-tekton-tasks-copy-template-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-"/usr/bin/kubevirt-tekton-tasks.test"
-]
-
-[[payload.kubevirt-tekton-tasks-operator-container.ignore]]
-error = "ErrGoNotCgoEnabled"
-files = [
-"/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/kubevirt-tekton-tasks.test"]
 
 [[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-"/usr/local/bin/disk-uploader",
-"/usr/local/bin/kubevirt-tekton-tasks.test"
+  "/usr/local/bin/disk-uploader",
+  "/usr/local/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = [
+  "/usr/local/bin/disk-uploader",
+  "/usr/local/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/local/bin/disk-uploader",
+  "/usr/local/bin/kubevirt-tekton-tasks.test"
+]
+
+[[payload.kubevirt-tekton-tasks-create-datavolume-rhel9-container.ignore]]
+error = "ErrLibcryptoMissing"
+files = [
+  "/usr/local/bin/disk-uploader",
+  "/usr/local/bin/kubevirt-tekton-tasks.test"
 ]
 
 [[payload.kubevirt-ssp-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-"/usr/bin/ssp-operator.test"
-]
+files = ["/usr/bin/ssp-operator.test"]
 
 [[payload.kubevirt-tekton-tasks-operator-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = [
-"/usr/bin/tekton-tasks-operator.test"
-]
+files = ["/usr/bin/tekton-tasks-operator.test"]


### PR DESCRIPTION
I've added (and tested locally) the exclusions we were missing on CNV. Those exclusions are on binaries that are on test containers that are not shipped to customers, or go binaries used by those same test containers.