### PR TITLE
Turn off usage on scan failures

### DIFF
--- a/internal/types/types_config.go
+++ b/internal/types/types_config.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (c *Config) Log() {
-	klog.Infof("using config %+v", c)
+	klog.V(1).Infof("using config %+v", c)
 }
 
 // isMatch tells if path equals to one of the entries.


### PR DESCRIPTION
- Turn off usage output on scan failures
- Prefer `Run()` when no errors are returned
- Put config output behind verbosity flag
