### PR TITLE
Ignore catatonit for kiali operator for OCP 4.15 and 4.14

### DIFF
--- a/dist/releases/4.14/config.toml
+++ b/dist/releases/4.14/config.toml
@@ -203,3 +203,7 @@ files = ["/usr/bin/container-disk"]
 [[payload.virt-launcher-rhel9-container.ignore]]
 error = "ErrNotDynLinked"
 files = ["/usr/bin/container-disk"]
+
+[[payload.openshift-istio-kiali-operator-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/libexec/catatonit/catatonit"]

--- a/dist/releases/4.15/config.toml
+++ b/dist/releases/4.15/config.toml
@@ -194,3 +194,7 @@ files = ["/usr/bin/container-disk"]
 [[payload.virt-launcher-rhel9-container.ignore]]
 error = "ErrNotDynLinked"
 files = ["/usr/bin/container-disk"]
+
+[[payload.openshift-istio-kiali-operator-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/libexec/catatonit/catatonit"]


### PR DESCRIPTION
Extending https://github.com/openshift/check-payload/pull/242 about OCP 4.14 and 4.15 since Konflux verifies fips for each OCP version.