### PR TITLE
Add CGO_ENABLED as an exclusion for ocp-virt-validation-checkup due to false positive

### DIFF
--- a/dist/releases/4.19/config.toml
+++ b/dist/releases/4.19/config.toml
@@ -536,3 +536,10 @@ files = [
   "/usr/sbin/build-locale-archive",
   "/usr/sbin/ldconfig"
 ]
+
+[[payload.ocp-virt-validation-checkup-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/test/kv.test",
+  "/test/ssp.test"
+]

--- a/dist/releases/4.20/config.toml
+++ b/dist/releases/4.20/config.toml
@@ -536,3 +536,10 @@ files = [
   "/usr/sbin/build-locale-archive",
   "/usr/sbin/ldconfig"
 ]
+
+[[payload.ocp-virt-validation-checkup-rhel9-container.ignore]]
+error = "ErrGoNotCgoEnabled"
+files = [
+  "/test/kv.test",
+  "/test/ssp.test"
+]


### PR DESCRIPTION
More information -> https://issues.redhat.com/browse/KFLUXSPRT-3109 and https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1747042738939379

It seems the tool is having a false positive with our ocp-virt-validation-checkup binary. Even if we are building it using the correct settings and the binary has C dependencies...

```
ENV GOEXPERIMENT strictfipsruntime
ENV GOFLAGS "-tags=strictfipsruntime"
RUN GOARCH=${TARGETARCH} GOOS=linux CGO_ENABLED=1 go test -c -o bin/kv.test ./tests
```

```
bash-5.1# ldd test/kv.test 
	linux-vdso.so.1 (0x00007fc004462000)
	libresolv.so.2 => /lib64/libresolv.so.2 (0x00007fc004446000)
	libc.so.6 => /lib64/libc.so.6 (0x00007fc00423e000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fc004464000)
bash-5.1# ldd test/ssp.test 
	linux-vdso.so.1 (0x00007f0ea4845000)
	libresolv.so.2 => /lib64/libresolv.so.2 (0x00007f0ea4829000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f0ea4621000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f0ea4847000)
```
	
Check-payload is giving us an error.

After more investigation was done, we found out the tool in order to verify if CGOEnabled is set, it uses the binary buildinfo, but for binaries created with go test don't include this metadata (and didn't find an easy way to include it). Hence we are requesting an exception.