### PR TITLE
CMP-3427: Update certified distributions to include RHEL 8.10

### DIFF
--- a/dist/releases/4.16/config.toml
+++ b/dist/releases/4.16/config.toml
@@ -1,6 +1,7 @@
 certified_distributions = [
   "Red Hat Enterprise Linux release 9.2 (Plow)",
   "Red Hat Enterprise Linux release 9.4 (Plow)",
+  "Red Hat Enterprise Linux release 8.10 (Ootpa)",
 ]
 
 [[payload.ubi9-container.ignore]]


### PR DESCRIPTION
RHEL 8.10 has a FIPS certification for openssl, but when we use the
`check-payload` tool it will fail on containers built with RHEL 8.10
base images because it fails the certified distribution check.

https://csrc.nist.gov/Projects/Cryptographic-Module-Validation-Program/Certificate/4642

Let's update the certified distributions configuration so that
containers built on RHEL 8.10 pass the check.

Only proposing this for 4.16 currently since most container images on
newer versions of OpenShift are using RHEL 9, which we already have
configured.
