### PR TITLE
Update OCP virt validation exception binary path

### DIFF
--- a/dist/releases/4.19/config.toml
+++ b/dist/releases/4.19/config.toml
@@ -540,6 +540,6 @@ files = [
 [[payload.ocp-virt-validation-checkup-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-  "/test/kv.test",
-  "/test/ssp.test"
+  "/usr/local/bin/kubevirt.test",
+  "/usr/local/bin/ssp.test"
 ]

--- a/dist/releases/4.20/config.toml
+++ b/dist/releases/4.20/config.toml
@@ -540,6 +540,6 @@ files = [
 [[payload.ocp-virt-validation-checkup-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = [
-  "/test/kv.test",
-  "/test/ssp.test"
+  "/usr/local/bin/kubevirt.test",
+  "/usr/local/bin/ssp.test"
 ]


### PR DESCRIPTION
Follow up of https://github.com/openshift/check-payload/pull/265

The binary path and name changed, so we are requesting to update the exception to the new name and path. Nothing else changed.