### PR TITLE
ignore ErrNotDynLinked for all valgrind rpm files

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -129,6 +129,21 @@ dirs = ["/usr/libexec/cni"]
 error = "ErrGoMissingTag"
 files = ["/usr/lib/dracut/modules.d/30ignition/ignition"]
 
+[[rpm.valgrind.ignore]]
+error = "ErrNotDynLinked"
+files = [
+    "/usr/libexec/valgrind/cachegrind-amd64-linux",
+    "/usr/libexec/valgrind/callgrind-amd64-linux",
+    "/usr/libexec/valgrind/dhat-amd64-linux",
+    "/usr/libexec/valgrind/drd-amd64-linux",
+    "/usr/libexec/valgrind/exp-bbv-amd64-linux",
+    "/usr/libexec/valgrind/helgrind-amd64-linux",
+    "/usr/libexec/valgrind/lackey-amd64-linux",
+    "/usr/libexec/valgrind/massif-amd64-linux",
+    "/usr/libexec/valgrind/memcheck-amd64-linux",
+    "/usr/libexec/valgrind/none-amd64-linux"
+]
+
 [[payload.openshift-enterprise-pod-container.ignore]]
 error = "ErrNotDynLinked"
 files = ["/usr/bin/pod"]


### PR DESCRIPTION
We've encountered ErrNotDynLinked errors on valgrind with multiple RHOAI images. Given valgrind is not performing cryptographic operations, is not a golang binary and would generally not compile any differently with CGO_ENABLED=1, we'd like to make a blanket ignore on it's files.

```
---- Failure Report
+----------------+---------------------------+----------------------------------------------+--------------------------------------+------------------------------------+
| OPERATOR NAME  | RPM NAME                  | EXECUTABLE NAME                              | STATUS                               | IMAGE                              |
+----------------+---------------------------+----------------------------------------------+--------------------------------------+------------------------------------+
| ubi9-container | habanalabs-firmware-tools | /usr/bin/hl-smi                              | executable is not dynamically linked | quay.io/modh/vllm:rhoai-2.19-gaudi |
| ubi9-container | valgrind                  | /usr/libexec/valgrind/cachegrind-amd64-linux | executable is not dynamically linked | quay.io/modh/vllm:rhoai-2.19-gaudi |
| ubi9-container | valgrind                  | /usr/libexec/valgrind/callgrind-amd64-linux  | executable is not dynamically linked | quay.io/modh/vllm:rhoai-2.19-gaudi |
| ubi9-container | valgrind                  | /usr/libexec/valgrind/dhat-amd64-linux       | executable is not dynamically linked | quay.io/modh/vllm:rhoai-2.19-gaudi |
| ubi9-container | valgrind                  | /usr/libexec/valgrind/drd-amd64-linux        | executable is not dynamically linked | quay.io/modh/vllm:rhoai-2.19-gaudi |
| ubi9-container | valgrind                  | /usr/libexec/valgrind/exp-bbv-amd64-linux    | executable is not dynamically linked | quay.io/modh/vllm:rhoai-2.19-gaudi |
| ubi9-container | valgrind                  | /usr/libexec/valgrind/helgrind-amd64-linux   | executable is not dynamically linked | quay.io/modh/vllm:rhoai-2.19-gaudi |
| ubi9-container | valgrind                  | /usr/libexec/valgrind/lackey-amd64-linux     | executable is not dynamically linked | quay.io/modh/vllm:rhoai-2.19-gaudi |
| ubi9-container | valgrind                  | /usr/libexec/valgrind/massif-amd64-linux     | executable is not dynamically linked | quay.io/modh/vllm:rhoai-2.19-gaudi |
| ubi9-container | valgrind                  | /usr/libexec/valgrind/memcheck-amd64-linux   | executable is not dynamically linked | quay.io/modh/vllm:rhoai-2.19-gaudi |
| ubi9-container | valgrind                  | /usr/libexec/valgrind/none-amd64-linux       | executable is not dynamically linked | quay.io/modh/vllm:rhoai-2.19-gaudi |
+----------------+---------------------------+----------------------------------------------+--------------------------------------+------------------------------------+
```