### PR TITLE
volsync-container exception for diskrsync binary (for ocp 4.14)

### DIFF
--- a/dist/releases/4.14/config.toml
+++ b/dist/releases/4.14/config.toml
@@ -19,6 +19,21 @@ files = [
 error = "ErrLibcryptoSoMissing"
 files = ["/opt/cni/bin/rhel9/openshift-sdn"]
 
+# VolSync packages diskrsync which uses x/crypto/blake2b for local hashing only
+# for comparing blocks of data (non-cryptographic)
+# Actual network transfer is handled by the ssh executable in the image
+[[payload.volsync-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = ["/usr/local/bin/diskrsync"]
+
+[[payload.volsync-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/local/bin/diskrsync"]
+
+[[payload.volsync-container.ignore]]
+error = "ErrLibcryptoMissing"
+files = ["/usr/local/bin/diskrsync"]
+
 [[payload.multus-cni-container.ignore]]
 error = "ErrLibcryptoSoMissing"
 dirs = ["/usr/src/multus-cni/rhel9/bin", "/usr/src/multus-cni/bin"]


### PR DESCRIPTION
- Back-porting exception that was only done from ocp 4.15 and up since that was the oldest CVP would use when running check-payload

- Now that we are building File-based catalogs for OCP versions in konflux, it appears the check-payload is run using the OCP 4.14 config for the ocp 4.14 FBC and so we get the failure again for `diskrsync`.

- Previous PR for reference: https://github.com/openshift/check-payload/pull/177