### PR TITLE
add RHEL 9.6 to certified_distributions for OCP 4.16

### DIFF
--- a/dist/releases/4.16/config.toml
+++ b/dist/releases/4.16/config.toml
@@ -1,6 +1,7 @@
 certified_distributions = [
   "Red Hat Enterprise Linux release 9.2 (Plow)",
   "Red Hat Enterprise Linux release 9.4 (Plow)",
+  "Red Hat Enterprise Linux release 9.6 (Plow)",
   "Red Hat Enterprise Linux release 8.10 (Ootpa)",
 ]
 


### PR DESCRIPTION
Adds RHEL 9.6 to the list of certified distributions for OCP 4.16.

Related issue: https://github.com/openshift/check-payload/issues/272

Note this does not resolve everything in the above issue, but will unblock failing scans on OCP 4.16 that use a RHEL 9.6 base image.

Remaining questions/problems from the above issue:
- Why does only OCP 4.16 have this list of certified distributions in the config.toml?
- Why do many images built with the same RHEL 9.6 base image pass the scan without this fix?