### PR TITLE
The MCE hypershift container needs changes to the exceptions in place

### DIFF
--- a/dist/releases/4.15/config.toml
+++ b/dist/releases/4.15/config.toml
@@ -178,7 +178,23 @@ files = [
 
 [[payload.multicluster-engine-hypershift-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
+files = ["/usr/bin/hcp", "/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
+
+[[payload.multicluster-engine-hypershift-operator-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = [
+  "/usr/bin/hcp",
+  "/usr/bin/hcp-no-cgo",
+  "/usr/bin/hypershift-no-cgo",
+]
+
+[[payload.multicluster-engine-hypershift-operator-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/hcp",
+  "/usr/bin/hcp-no-cgo",
+  "/usr/bin/hypershift-no-cgo",
+]
 
 [[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"

--- a/dist/releases/4.16/config.toml
+++ b/dist/releases/4.16/config.toml
@@ -462,7 +462,23 @@ files = ["/tools/opm-rhel8"]
 
 [[payload.multicluster-engine-hypershift-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
+files = ["/usr/bin/hcp", "/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
+
+[[payload.multicluster-engine-hypershift-operator-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = [
+  "/usr/bin/hcp",
+  "/usr/bin/hcp-no-cgo",
+  "/usr/bin/hypershift-no-cgo",
+]
+
+[[payload.multicluster-engine-hypershift-operator-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/hcp",
+  "/usr/bin/hcp-no-cgo",
+  "/usr/bin/hypershift-no-cgo",
+]
 
 [[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"

--- a/dist/releases/4.17/config.toml
+++ b/dist/releases/4.17/config.toml
@@ -453,11 +453,23 @@ files = ["/unpack"]
 # containers for QE testing.
 [[payload.multicluster-engine-hypershift-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
+files = ["/usr/bin/hcp", "/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
 
 [[payload.multicluster-engine-hypershift-operator-container.ignore]]
-error = "ErrGoNotCgoEnabled"
-files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
+error = "ErrGoMissingSymbols"
+files = [
+  "/usr/bin/hcp",
+  "/usr/bin/hcp-no-cgo",
+  "/usr/bin/hypershift-no-cgo",
+]
+
+[[payload.multicluster-engine-hypershift-operator-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/hcp",
+  "/usr/bin/hcp-no-cgo",
+  "/usr/bin/hypershift-no-cgo",
+]
 
 [[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"

--- a/dist/releases/4.18/config.toml
+++ b/dist/releases/4.18/config.toml
@@ -451,7 +451,23 @@ files = ["/unpack"]
 
 [[payload.multicluster-engine-hypershift-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
+files = ["/usr/bin/hcp", "/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
+
+[[payload.multicluster-engine-hypershift-operator-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = [
+  "/usr/bin/hcp",
+  "/usr/bin/hcp-no-cgo",
+  "/usr/bin/hypershift-no-cgo",
+]
+
+[[payload.multicluster-engine-hypershift-operator-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/hcp",
+  "/usr/bin/hcp-no-cgo",
+  "/usr/bin/hypershift-no-cgo",
+]
 
 [[payload.hco-bundle-registry-container.ignore]]
 error = "ErrNotDynLinked"

--- a/dist/releases/4.19/config.toml
+++ b/dist/releases/4.19/config.toml
@@ -442,7 +442,23 @@ files = ["/unpack"]
 
 [[payload.multicluster-engine-hypershift-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
+files = ["/usr/bin/hcp", "/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
+
+[[payload.multicluster-engine-hypershift-operator-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = [
+  "/usr/bin/hcp",
+  "/usr/bin/hcp-no-cgo",
+  "/usr/bin/hypershift-no-cgo",
+]
+
+[[payload.multicluster-engine-hypershift-operator-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/hcp",
+  "/usr/bin/hcp-no-cgo",
+  "/usr/bin/hypershift-no-cgo",
+]
 
 [[payload.multicluster-engine-hypershift-cli-container.ignore]]
 error = "ErrGoNotCgoEnabled"

--- a/dist/releases/4.20/config.toml
+++ b/dist/releases/4.20/config.toml
@@ -442,7 +442,23 @@ files = ["/unpack"]
 
 [[payload.multicluster-engine-hypershift-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
+files = ["/usr/bin/hcp", "/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
+
+[[payload.multicluster-engine-hypershift-operator-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = [
+  "/usr/bin/hcp",
+  "/usr/bin/hcp-no-cgo",
+  "/usr/bin/hypershift-no-cgo",
+]
+
+[[payload.multicluster-engine-hypershift-operator-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/hcp",
+  "/usr/bin/hcp-no-cgo",
+  "/usr/bin/hypershift-no-cgo",
+]
 
 [[payload.multicluster-engine-hypershift-cli-container.ignore]]
 error = "ErrGoNotCgoEnabled"

--- a/dist/releases/4.21/config.toml
+++ b/dist/releases/4.21/config.toml
@@ -442,7 +442,23 @@ files = ["/unpack"]
 
 [[payload.multicluster-engine-hypershift-operator-container.ignore]]
 error = "ErrGoNotCgoEnabled"
-files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
+files = ["/usr/bin/hcp", "/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
+
+[[payload.multicluster-engine-hypershift-operator-container.ignore]]
+error = "ErrGoMissingSymbols"
+files = [
+  "/usr/bin/hcp",
+  "/usr/bin/hcp-no-cgo",
+  "/usr/bin/hypershift-no-cgo",
+]
+
+[[payload.multicluster-engine-hypershift-operator-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/usr/bin/hcp",
+  "/usr/bin/hcp-no-cgo",
+  "/usr/bin/hypershift-no-cgo",
+]
 
 [[payload.multicluster-engine-hypershift-cli-container.ignore]]
 error = "ErrGoNotCgoEnabled"


### PR DESCRIPTION
The FIPS scans are failing in our konflux builds due to problems with the hypershift "extra" binaries.  The current exceptions for these binaries is not correctly preventing the scanner from erroring on these binaries. Tested with the latest image from our MCE 2.18.3 release

Refs:
 - https://issues.redhat.com/browse/ACM-24281