### PR TITLE
fix: 4.12 rhcos tag ignore tag name

### DIFF
--- a/dist/releases/4.12/config.toml
+++ b/dist/releases/4.12/config.toml
@@ -3,9 +3,9 @@
 # This image doesn't have typical component metadata and isn't a layered product.
 # The RHCOS team uses OpenShift releases as a transport mechanism for this base OS.
 # This issue was resolved in OpenShift 4.19+ but affects earlier versions.
-[[tag.rhel-coreos.ignore]]
+[[tag.rhel-coreos-8.ignore]]
 error = "ErrOSNotCertified"
-tags = ["rhel-coreos"]
+tags = ["rhel-coreos-8"]
 
 [[payload.openshift-enterprise-operator-sdk-container.ignore]]
 error = "ErrGoMissingSymbols"


### PR DESCRIPTION
Appears the rhel-coreos tag name differs for 4.12, adjusting for rhec-coreos to ignore os rule scan. RHCOS image is used as transport by openshift payload and is an exception for this within the openshift payload. 4.19 and on rhcos modified the redhat-release so it shouldn't fail for those versions and up.

Tested with the following: 

./check-payload scan payload -V 4.12 --url registry.ci.openshift.org/ocp/release:4.12.0-0.nightly-2025-10-06-135553

./check-payload scan payload -V 4.12 --url quay.io/openshift-release-dev/ocp-release:4.12.77-x86_64