### PR TITLE
fix: update component name for hypershift-operator

### DIFF
--- a/dist/releases/4.13/config.toml
+++ b/dist/releases/4.13/config.toml
@@ -103,7 +103,7 @@ files = ["/usr/bin/cpb"]
 error = "ErrLibcryptoMissing"
 files = ["/usr/bin/cpb"]
 
-[[payload.multicluster-engine-hypershift-operator-container.ignore]]
+[[payload.multicluster-engine-hypershift-operator.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
 

--- a/dist/releases/4.14/config.toml
+++ b/dist/releases/4.14/config.toml
@@ -156,7 +156,7 @@ files = [
   "/usr/libexec/cni/vlan",
 ]
 
-[[payload.multicluster-engine-hypershift-operator-container.ignore]]
+[[payload.multicluster-engine-hypershift-operator.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
 

--- a/dist/releases/4.15/config.toml
+++ b/dist/releases/4.15/config.toml
@@ -176,7 +176,7 @@ files = [
   "/usr/libexec/cni/vlan",
 ]
 
-[[payload.multicluster-engine-hypershift-operator-container.ignore]]
+[[payload.multicluster-engine-hypershift-operator.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
 

--- a/dist/releases/4.16/config.toml
+++ b/dist/releases/4.16/config.toml
@@ -460,7 +460,7 @@ files = ["/unpack"]
 error = "ErrLibcryptoSoMissing"
 files = ["/tools/opm-rhel8"]
 
-[[payload.multicluster-engine-hypershift-operator-container.ignore]]
+[[payload.multicluster-engine-hypershift-operator.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
 

--- a/dist/releases/4.17/config.toml
+++ b/dist/releases/4.17/config.toml
@@ -451,13 +451,10 @@ files = ["/unpack"]
 
 # These binaries are not built with CGO enabled because they're convenience
 # containers for QE testing.
-[[payload.multicluster-engine-hypershift-operator-container.ignore]]
+[[payload.multicluster-engine-hypershift-operator.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
 
-[[payload.multicluster-engine-hypershift-operator-container.ignore]]
-error = "ErrGoNotCgoEnabled"
-files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
 
 [[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"

--- a/dist/releases/4.18/config.toml
+++ b/dist/releases/4.18/config.toml
@@ -449,7 +449,7 @@ files = ["/usr/bin/cpb"]
 error = "ErrGoNotCgoEnabled"
 files = ["/unpack"]
 
-[[payload.multicluster-engine-hypershift-operator-container.ignore]]
+[[payload.multicluster-engine-hypershift-operator.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
 

--- a/dist/releases/4.19/config.toml
+++ b/dist/releases/4.19/config.toml
@@ -440,7 +440,7 @@ files = ["/usr/bin/cpb"]
 error = "ErrGoNotCgoEnabled"
 files = ["/unpack"]
 
-[[payload.multicluster-engine-hypershift-operator-container.ignore]]
+[[payload.multicluster-engine-hypershift-operator.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
 

--- a/dist/releases/4.20/config.toml
+++ b/dist/releases/4.20/config.toml
@@ -440,7 +440,7 @@ files = ["/usr/bin/cpb"]
 error = "ErrGoNotCgoEnabled"
 files = ["/unpack"]
 
-[[payload.multicluster-engine-hypershift-operator-container.ignore]]
+[[payload.multicluster-engine-hypershift-operator.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
 

--- a/dist/releases/4.21/config.toml
+++ b/dist/releases/4.21/config.toml
@@ -440,7 +440,7 @@ files = ["/usr/bin/cpb"]
 error = "ErrGoNotCgoEnabled"
 files = ["/unpack"]
 
-[[payload.multicluster-engine-hypershift-operator-container.ignore]]
+[[payload.multicluster-engine-hypershift-operator.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = ["/usr/bin/hcp-no-cgo", "/usr/bin/hypershift-no-cgo"]
 


### PR DESCRIPTION
Looking at the `com.redhat.component` label on the container, looks like there's a misalignment here:

```dockerfile
LABEL com.redhat.component="multicluster-engine-hypershift-operator"
```

ref: https://github.com/openshift/hypershift/blob/66a7017f8635603d855b2ecbc16f52ff55df06d0/Containerfile.operator#L28