### PR TITLE
Add 9.7 to the list of FIPS validated releases

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -10,6 +10,7 @@ certified_distributions = [
   "Red Hat Enterprise Linux release 9.4 (Plow)",
   "Red Hat Enterprise Linux release 9.5 (Plow)",
   "Red Hat Enterprise Linux release 9.6 (Plow)",
+  "Red Hat Enterprise Linux release 9.7 (Plow)",
 ]
 
 # List of directories to ignore. This is a prefix match,


### PR DESCRIPTION
UBI9 is now 9.7 so add it

Without this releases will likely be blocked as soon as rhel-coreos gets rebuilt since it uses UBI9 as the base image. It's happened on 4.14 here 
https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.14-fips-payload-scan/1988644702873718784