### PR TITLE
Add 9.8 beta to certified_distributions for 4.22

### DIFF
--- a/dist/releases/4.22/config.toml
+++ b/dist/releases/4.22/config.toml
@@ -1,3 +1,8 @@
+certified_distributions = [
+  "Red Hat Enterprise Linux release 9.8 Beta (Plow)",
+]
+
+
 [[payload.ose-network-interface-bond-cni-container.ignore]]
 error = "ErrLibcryptoSoMissing"
 files = ["/bondcni/bond", "/bondcni/rhel9/bond"]

--- a/dist/releases/4.22/config.toml
+++ b/dist/releases/4.22/config.toml
@@ -565,3 +565,9 @@ files = [
   "/checode-linux-libc/ubi8/node_modules/@vscode/ripgrep/bin/rg",
   "/checode-linux-libc/ubi9/node_modules/@vscode/ripgrep/bin/rg"
 ]
+
+# In 4.21 and 4.22 we'll have a rhel-coreos-10 and rhel-coreos-10-extensions image
+# these images are devpreview / techpreview and thus not beholden to FIPS validation
+[[tag.rhel-coreos-10.ignore]]
+error = "ErrOSNotCertified"
+tags = ["rhel-coreos-10"]


### PR DESCRIPTION
The OpenSSL FIPS provider in 9.8 beta is the same version as that used since 9.4.

```
podman run -it --entrypoint /bin/sh `oc adm release info --image-for rhel-coreos registry.ci.openshift.org/ocp/release:4.22.0-0.nightly-2026-02-16-121727` -c "cat /etc/redhat-release && rpm -q openssl-fips-provider"
Red Hat Enterprise Linux release 9.8 Beta (Plow)
openssl-fips-provider-3.0.7-8.el9.x86_64
```