### PR TITLE
Add OS certification exception for rhel-coreos-10 in 5.0 config

### DIFF
--- a/dist/releases/4.23/config.toml
+++ b/dist/releases/4.23/config.toml
@@ -565,3 +565,9 @@ files = [
   "/checode-linux-libc/ubi8/node_modules/@vscode/ripgrep/bin/rg",
   "/checode-linux-libc/ubi9/node_modules/@vscode/ripgrep/bin/rg"
 ]
+
+# In 4.23 we have a rhel-coreos-10 image
+# this image is devpreview / techpreview and thus not beholden to FIPS validation
+[[tag.rhel-coreos-10.ignore]]
+error = "ErrOSNotCertified"
+tags = ["rhel-coreos-10"]

--- a/dist/releases/5.0/config.toml
+++ b/dist/releases/5.0/config.toml
@@ -565,3 +565,9 @@ files = [
   "/checode-linux-libc/ubi8/node_modules/@vscode/ripgrep/bin/rg",
   "/checode-linux-libc/ubi9/node_modules/@vscode/ripgrep/bin/rg"
 ]
+
+# In 5.0 we have a rhel-coreos-10 image
+# this image is devpreview / techpreview and thus not beholden to FIPS validation
+[[tag.rhel-coreos-10.ignore]]
+error = "ErrOSNotCertified"
+tags = ["rhel-coreos-10"]

--- a/dist/releases/5.0/config.toml
+++ b/dist/releases/5.0/config.toml
@@ -566,8 +566,7 @@ files = [
   "/checode-linux-libc/ubi9/node_modules/@vscode/ripgrep/bin/rg"
 ]
 
-# In 5.0 we have a rhel-coreos-10 image
-# this image is devpreview / techpreview and thus not beholden to FIPS validation
+# FIPS status is non blocker for RHCOS10 in 5.0
 [[tag.rhel-coreos-10.ignore]]
 error = "ErrOSNotCertified"
 tags = ["rhel-coreos-10"]


### PR DESCRIPTION
## Summary
- Fixes FIPS scan failure for `rhel-coreos-10` tag with "operating system is not FIPS certified" error
- Adds tag-based exception to both `dist/releases/4.23/config.toml` and `dist/releases/5.0/config.toml`
- Matches the pattern from 4.21 and 4.22 configs

## Root Cause
The `rhel-coreos-10` image contains RHEL 9.8 Beta which is not in the `certified_distributions` list. The scanner checks OS validation and reports `ErrOSNotCertified` when no exception is found.

## Solution
Added `[[tag.rhel-coreos-10.ignore]]` sections to both 4.23 and 5.0 configs since this image is dev/tech preview and not subject to FIPS validation requirements.

## Changes
- **4.23 config:** Missing exception when branch was created on April 20, 2026
- **5.0 config:** Missing exception (4.22 has it, 5.0 did not)

## Testing
- Verified 4.21 and 4.22 configs have identical exception and work correctly
- Exception follows established pattern for tag-based OS certification ignores

## References
- Original exception added in PR #302 by Scott Dodson
- Applied to 4.22 in PR #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)
