### PR TITLE
Exempt vllm-gaudi /usr/bin/hl-smi

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -158,6 +158,10 @@ files = [
   "/usr/libexec/valgrind/none-amd64-linux",
 ]
 
+[[payload.odh-vllm-gaudi-rhel9.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/bin/hl-smi"]
+
 [[payload.openshift-enterprise-pod-container.ignore]]
 error = "ErrNotDynLinked"
 files = ["/usr/bin/pod"]

--- a/config.toml
+++ b/config.toml
@@ -158,7 +158,8 @@ files = [
   "/usr/libexec/valgrind/none-amd64-linux",
 ]
 
-[[payload.odh-vllm-gaudi-rhel9.ignore]]
+[[rpm.habanalabs-firmware-tools.ignore]]
+# hl-smi: Intel Gaudi hardware monitor, static by design, no crypto.
 error = "ErrNotDynLinked"
 files = ["/usr/bin/hl-smi"]
 


### PR DESCRIPTION
hl-smi is the main tool for monitoring a gaudi hardware accelerator. It cannot be removed. It is built by Intel so there's nothing we can do to solve the problem. It is likely static so that it can run on Red Hat or Ubuntu without worrying is library versions are compatible.