### PR TITLE
chore: migrate .golangci.yml to v2 format

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,28 @@
 # For documentation, see https://golangci-lint.run/usage/configuration/
-
-run:
-  timeout: 5m
-
+version: "2"
 linters:
   enable:
-    - gofumpt
     - errorlint
+    - revive
     - unconvert
     - unparam
-    - revive
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofumpt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
## Summary

golangci-lint v2 requires a `version: "2"` field in the config file. Without it, the linter refuses to run:

```
Error: can't load config: unsupported version of the configuration: ""
See https://golangci-lint.run/docs/product/migration-guide for migration instructions
```

This was generated with `golangci-lint migrate`. Notable changes:
- `gofumpt` moved from `linters` to `formatters` (v2 distinguishes formatters from linters)
- `run.timeout` removed (disabled by default in v2)
- Default exclusion presets added by the migration tool

Note: one pre-existing `staticcheck` finding (`QF1008` in `internal/types/types_config.go:143`) is now surfaced. It was not previously visible because the v1 config suppressed it.

Made with [Cursor](https://cursor.com)