### PR TITLE
fix: reject empty symbol table from ReadTable

### DIFF
--- a/internal/validations/validations.go
+++ b/internal/validations/validations.go
@@ -97,6 +97,9 @@ func _loadGoSymbols(_ context.Context, path string, baton *Baton) *types.Validat
 	if err != nil {
 		return types.NewValidationError(fmt.Errorf("go: could not read table for %v: %w", filepath.Base(path), err))
 	}
+	if len(symtable.Funcs) == 0 {
+		return types.NewValidationError(fmt.Errorf("go: symbol table for %v has no functions (pclntab may be corrupt)", filepath.Base(path)))
+	}
 	baton.GoSymTable = symtable
 	if !isUsingCryptoModule(baton.GoSymTable) {
 		baton.GoNoCrypto = true


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHAIENG-4982

## Summary

Follow-up to #330. Add a guard in `_loadGoSymbols` to reject symbol tables
with zero functions.

A Go binary always has functions in its pclntab — even a trivial `func main() {}`
produces hundreds of runtime functions. An empty symbol table indicates the
pclntab was parsed from corrupt or unrelated data (e.g., a coincidental magic
byte match in the wrong ELF section).

## Problem

Without this guard, an empty table causes `isUsingCryptoModule` to return
`false` (no functions to iterate → no `crypto` found), setting `GoNoCrypto=true`.
This silently skips **all** subsequent FIPS validation:
- `validateGoSymbols` — skipped
- `validateGoCgo` — skipped
- `validateGoCGOInit` — skipped
- `validateGoStatic` — skipped
- `validateGoOpenssl` — skipped

The binary passes check-payload with no errors and no warnings, even though
no actual validation was performed.

## How we discovered this

During analysis for #329, we found that on amd64 Go 1.26 PIE binaries, the
old buggy section lookup read `.data.rel.ro` instead of `.gopclntab`. The BE
magic `ff ff ff f1` matched at a coincidental offset in `.data.rel.ro`,
producing an empty `gosym.Table` (0 funcs). The scan appeared to succeed
but performed zero Go FIPS validation.

## Change

```go
if len(symtable.Funcs) == 0 {
    return types.NewValidationError(fmt.Errorf(
        "go: symbol table for %v has no functions (pclntab may be corrupt)",
        filepath.Base(path)))
}
```

Made with [Cursor](https://cursor.com)