### PR TITLE
fix(fips): unified module validation with version-gated artifact checks

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -16,18 +16,37 @@ certified_distributions = [
   "Red Hat Enterprise Linux release 10.1 (Coughlan)",
 ]
 
-# FIPS certified modules (or in-process). Each entry defines a crypto stack
-# and its certified artifact. Host library checks are code-driven (see
-# validations_host_crypto.go moduleHostLibChecks registry).
+# FIPS certified modules. Multiple entries per module are alternatives — first match wins.
 fips_certified_modules = [
+  # OpenSSL 3.x FIPS Provider (CMVP #4282) — RHEL 9.4+
   { module = "openssl",
+    artifact_source = "image",
     certified_artifact = "openssl-fips-provider",
     certified_artifact_min_version = "3.0.7",
-    certified_artifact_paths = ["/usr/lib64/ossl-modules/fips.so", "/usr/lib/ossl-modules/fips.so"],
+    certified_artifact_paths = ["/usr/lib64/ossl-modules/fips.so"],
   },
-  # Go native FIPS (CMVP #5247): embedded in binary at build time.
-  # Validated by validateGoNativeFIPS; no image-level artifact needed.
-  # { module = "go", certified_artifact = "crypto/fips140" },
+  # OpenSSL 3.x FIPS Provider (CMVP #4282) — RHEL 9.2-9.3
+  # Same certified module, different package: fips.so shipped inside openssl-libs.
+  { module = "openssl",
+    artifact_source = "image",
+    certified_artifact = "openssl-libs",
+    certified_artifact_min_version = "3.0.7",
+    certified_artifact_max_version = "3.0.7",
+    certified_artifact_paths = ["/usr/lib64/ossl-modules/fips.so"],
+  },
+  # OpenSSL 1.1.1 FIPS (CMVP #3842) — RHEL 8
+  { module = "openssl",
+    artifact_source = "image",
+    certified_artifact = "openssl-libs",
+    certified_artifact_min_version = "1.1.1",
+    certified_artifact_max_version = "1.1.1",
+  },
+  # Go FIPS 140 (CMVP #5247)
+  { module = "go",
+    artifact_source = "binary",
+    certified_artifact = "crypto/fips140",
+    certified_artifact_min_version = "v1.0.0",
+  },
 ]
 
 # List of directories to ignore. This is a prefix match,

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -392,6 +392,13 @@ func validateOSPhase(_ context.Context, cfg *types.Config, tag *v1.TagReference,
 }
 
 func scanBinariesPhase(ctx context.Context, cfg *types.Config, tag *v1.TagReference, component *types.OpenshiftComponent, mountPath string, results *types.ScanResults) {
+	for _, m := range cfg.GetFIPSCertifiedModules() {
+		if m.Module == "go" && m.IsBinarySource() && m.CertifiedArtifactMinVersion != "" {
+			validations.SetGoFIPSMinVersion(m.CertifiedArtifactMinVersion)
+			break
+		}
+	}
+
 	errIgnoreLists := []types.ErrIgnoreList{cfg.ErrIgnores}
 	if tag != nil {
 		if i, ok := cfg.TagIgnores[tag.Name]; ok {
@@ -480,19 +487,17 @@ func validateModuleArtifactsPhase(ctx context.Context, cfg *types.Config, tag *v
 		modulesInUse = append(modulesInUse, m)
 	}
 	klog.V(1).InfoS("fips module validation", "modulesDetected", modulesInUse, "mountPath", mountPath)
-	if ve := validations.ValidateModuleArtifacts(ctx, cfg, mountPath, modulesInUse); ve != nil {
-		klog.InfoS("fips module validation failed", "error", ve.Error, "mountPath", mountPath)
-		results.Append(types.NewScanResult().SetValidationError(ve).SetComponent(component).SetTag(tag))
-	} else {
-		klog.V(1).InfoS("fips module validation passed", "mountPath", mountPath)
-	}
 
-	for _, ve := range validations.ValidateHostLibsForModules(ctx, mountPath, modulesInUseSet) {
-		if cfg.Java {
-			ve.SetWarning()
+	for _, module := range modulesInUse {
+		if ve := validations.ValidateModule(ctx, cfg, mountPath, module); ve != nil {
+			if cfg.Java {
+				ve.SetWarning()
+			}
+			klog.InfoS("fips module validation failed", "module", module, "error", ve.Error, "mountPath", mountPath)
+			results.Append(types.NewScanResult().SetValidationError(ve).SetComponent(component).SetTag(tag))
+		} else {
+			klog.V(1).InfoS("fips module validation passed", "module", module, "mountPath", mountPath)
 		}
-		klog.InfoS("host lib fips check failed", "error", ve.Error, "mountPath", mountPath)
-		results.Append(types.NewScanResult().SetValidationError(ve).SetComponent(component).SetTag(tag))
 	}
 }
 
@@ -516,7 +521,8 @@ func logPipelineSummary(tag *v1.TagReference, component *types.OpenshiftComponen
 	for m := range modules {
 		moduleList = append(moduleList, m)
 	}
-	klog.V(1).InfoS("pipeline complete",
+	klog.V(1).InfoS(
+		"pipeline complete",
 		"image", getTag(&types.ScanResult{Tag: tag}),
 		"component", getComponent(&types.ScanResult{Component: component}),
 		"total", len(results.Items),

--- a/internal/scan/scan_test.go
+++ b/internal/scan/scan_test.go
@@ -35,11 +35,18 @@ var (
 			FIPSCertifiedModules: []types.FipsModule{
 				{
 					Module:            "openssl",
+					ArtifactSource:    "image",
 					CertifiedArtifact: "openssl-fips-provider",
 					CertifiedArtifactPaths: []string{
 						"/usr/lib64/ossl-modules/fips.so",
 						"/usr/lib/ossl-modules/fips.so",
 					},
+				},
+				{
+					Module:                      "go",
+					ArtifactSource:              "binary",
+					CertifiedArtifact:           "crypto/fips140",
+					CertifiedArtifactMinVersion: "v1.0.0",
 				},
 			},
 		},
@@ -57,11 +64,18 @@ var (
 			FIPSCertifiedModules: []types.FipsModule{
 				{
 					Module:            "openssl",
+					ArtifactSource:    "image",
 					CertifiedArtifact: "openssl-fips-provider",
 					CertifiedArtifactPaths: []string{
 						"/usr/lib64/ossl-modules/fips.so",
 						"/usr/lib/ossl-modules/fips.so",
 					},
+				},
+				{
+					Module:                      "go",
+					ArtifactSource:              "binary",
+					CertifiedArtifact:           "crypto/fips140",
+					CertifiedArtifactMinVersion: "v1.0.0",
 				},
 			},
 		},

--- a/internal/types/error_map.go
+++ b/internal/types/error_map.go
@@ -6,6 +6,7 @@ var KnownErrors = map[string]error {
 	"ErrCertifiedDistributionsEmpty": ErrCertifiedDistributionsEmpty,
 	"ErrDistributionFileMissing": ErrDistributionFileMissing,
 	"ErrFipsArtifactMissing": ErrFipsArtifactMissing,
+	"ErrFipsArtifactVersionHigh": ErrFipsArtifactVersionHigh,
 	"ErrFipsArtifactVersionLow": ErrFipsArtifactVersionLow,
 	"ErrGoFIPSNotAuto": ErrGoFIPSNotAuto,
 	"ErrGoFIPSNotCertified": ErrGoFIPSNotCertified,

--- a/internal/types/errors.go
+++ b/internal/types/errors.go
@@ -23,6 +23,7 @@ var (
 	ErrCertifiedDistributionsEmpty = errors.New("certified_distributions is empty, consider using -V [VERSION] for check-payload")
 	ErrFipsArtifactMissing         = errors.New("required FIPS certified artifact not found")
 	ErrFipsArtifactVersionLow      = errors.New("FIPS certified artifact version below required minimum")
+	ErrFipsArtifactVersionHigh     = errors.New("FIPS certified artifact version above certified maximum")
 	ErrGoFIPSNotAuto               = errors.New("go binary does not set GODEBUG fips140=auto")
 	ErrGoFIPSNotCertified          = errors.New("go binary not built with GOFIPS140 FIPS module")
 )

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -9,24 +9,29 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-var leadingSemverRE = regexp.MustCompile(`^(\d+\.\d+\.\d+)`)
+var leadingSemverRE = regexp.MustCompile(`^v?(\d+\.\d+\.\d+)`)
 
-// VersionAtLeast compares an installed version string (which may have
-// RPM suffixes like "3.0.7-1.el9_4") against a minimum semver floor.
-func VersionAtLeast(installed, minVersion string) bool {
+// VersionInRange checks installed version against optional min/max bounds.
+func VersionInRange(installed, minVersion, maxVersion string) (atLeast, atMost bool) {
 	sv := leadingSemverRE.FindString(installed)
 	if sv == "" {
-		return false
+		return false, false
 	}
 	v, err := semver.NewVersion(sv)
 	if err != nil {
-		return false
+		return false, false
 	}
-	c, err := semver.NewConstraint(">= " + minVersion)
-	if err != nil {
-		return false
+	atLeast = true
+	if minVersion != "" {
+		c, err := semver.NewConstraint(">= " + minVersion)
+		atLeast = err == nil && c.Check(v)
 	}
-	return c.Check(v)
+	atMost = true
+	if maxVersion != "" {
+		c, err := semver.NewConstraint("<= " + maxVersion)
+		atMost = err == nil && c.Check(v)
+	}
+	return atLeast, atMost
 }
 
 type Config struct {
@@ -93,12 +98,18 @@ type ArtifactPod struct {
 }
 
 // FipsModule maps a crypto stack to its FIPS-certified artifact and version requirements.
-// Parsed from fips_certified_modules config entries.
+// ArtifactSource: "image" (default) = RPM/file in container, "binary" = embedded in binary.
 type FipsModule struct {
 	Module                      string   `json:"module" toml:"module"`
-	CertifiedArtifact           string   `json:"certified_artifact" toml:"certified_artifact"`
-	CertifiedArtifactMinVersion string   `json:"certified_artifact_min_version" toml:"certified_artifact_min_version"`
-	CertifiedArtifactPaths      []string `json:"certified_artifact_paths" toml:"certified_artifact_paths"`
+	ArtifactSource              string   `json:"artifact_source,omitempty" toml:"artifact_source"`
+	CertifiedArtifact           string   `json:"certified_artifact,omitempty" toml:"certified_artifact"`
+	CertifiedArtifactMinVersion string   `json:"certified_artifact_min_version,omitempty" toml:"certified_artifact_min_version"`
+	CertifiedArtifactMaxVersion string   `json:"certified_artifact_max_version,omitempty" toml:"certified_artifact_max_version"`
+	CertifiedArtifactPaths      []string `json:"certified_artifact_paths,omitempty" toml:"certified_artifact_paths"`
+}
+
+func (m FipsModule) IsBinarySource() bool {
+	return m.ArtifactSource == "binary"
 }
 
 type ScanResult struct {

--- a/internal/types/types_config_file.go
+++ b/internal/types/types_config_file.go
@@ -81,7 +81,10 @@ func validateFIPSCertifiedModules(perr *error, modules []FipsModule) {
 		if m.Module == "" {
 			multierr.AppendInto(perr, &errInvalidFIPSModule{Index: i, Field: "module"})
 		}
-		if m.CertifiedArtifact == "" {
+		if m.ArtifactSource != "" && m.ArtifactSource != "image" && m.ArtifactSource != "binary" {
+			multierr.AppendInto(perr, &errInvalidFIPSModule{Index: i, Field: `artifact_source (must be "image" or "binary")`})
+		}
+		if m.ArtifactSource != "binary" && m.CertifiedArtifact == "" {
 			multierr.AppendInto(perr, &errInvalidFIPSModule{Index: i, Field: "certified_artifact"})
 		}
 	}

--- a/internal/types/types_config_file_test.go
+++ b/internal/types/types_config_file_test.go
@@ -174,6 +174,47 @@ func TestFIPSValidation(t *testing.T) {
 			t.Error("expected error for empty module/artifact fields")
 		}
 	})
+
+	t.Run("binary source allows empty certified_artifact", func(t *testing.T) {
+		cfg := &types.ConfigFile{
+			FIPSCertifiedModules: []types.FipsModule{
+				{Module: "go", ArtifactSource: "binary"},
+			},
+		}
+		err, _ := cfg.Validate()
+		if err != nil {
+			t.Errorf("unexpected error for binary source: %v", err)
+		}
+	})
+
+	t.Run("invalid artifact_source", func(t *testing.T) {
+		cfg := &types.ConfigFile{
+			FIPSCertifiedModules: []types.FipsModule{
+				{Module: "openssl", ArtifactSource: "bogus", CertifiedArtifact: "x"},
+			},
+		}
+		err, _ := cfg.Validate()
+		if err == nil {
+			t.Error("expected error for invalid artifact_source")
+		}
+	})
+
+	t.Run("max version parses and validates", func(t *testing.T) {
+		cfg := &types.ConfigFile{
+			FIPSCertifiedModules: []types.FipsModule{
+				{
+					Module:                      "openssl",
+					CertifiedArtifact:           "openssl-libs",
+					CertifiedArtifactMinVersion: "1.1.1",
+					CertifiedArtifactMaxVersion: "1.1.1",
+				},
+			},
+		}
+		err, _ := cfg.Validate()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
 }
 
 func TestConfigMerge(t *testing.T) {

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -2,24 +2,43 @@ package types
 
 import "testing"
 
-func TestVersionAtLeast(t *testing.T) {
+func TestVersionInRange(t *testing.T) {
 	tests := []struct {
+		name      string
 		installed string
-		min       string
-		want      bool
+		min, max  string
+		wantMin   bool
+		wantMax   bool
 	}{
-		{"3.0.1", "3.0.0", true},
-		{"3.0.1-1.el9", "3.0.0", true},
-		{"3.0.0", "3.0.0", true},
-		{"2.9.0", "3.0.0", false},
-		{"", "3.0.0", false},
-		{"3.0.0", "3.0.1", false},
-		{"3.0.7", "3.0.7", true},
-		{"3.0.7-1.el9_4", "3.0.7", true},
+		{"above min", "3.0.1", "3.0.0", "", true, true},
+		{"rpm suffix above min", "3.0.1-1.el9", "3.0.0", "", true, true},
+		{"equal to min", "3.0.0", "3.0.0", "", true, true},
+		{"below min", "2.9.0", "3.0.0", "", false, true},
+		{"empty installed", "", "3.0.0", "", false, false},
+		{"below min exact", "3.0.0", "3.0.1", "", false, true},
+		{"rpm suffix equal", "3.0.7-1.el9_4", "3.0.7", "", true, true},
+		{"v-prefix equal", "v1.0.0", "v1.0.0", "", true, true},
+		{"v-prefix with hash", "v1.0.0-c2097c7c", "v1.0.0", "", true, true},
+
+		{"at max", "1.1.1", "", "1.1.1", true, true},
+		{"below max", "1.0.0", "", "1.1.1", true, true},
+		{"rpm suffix at max", "1.1.1-72.el8_8", "", "1.1.1", true, true},
+		{"above max", "3.0.7-1.el9_4", "", "1.1.1", true, false},
+		{"above max no suffix", "3.0.7", "", "1.1.1", true, false},
+		{"above max by patch", "3.0.8", "", "3.0.7", true, false},
+
+		{"in range", "1.1.1-72.el8_8", "1.1.1", "1.1.1", true, true},
+		{"below range", "1.0.0", "1.1.1", "1.1.1", false, true},
+		{"above range", "3.0.7", "1.1.1", "1.1.1", true, false},
+		{"no bounds", "3.0.7", "", "", true, true},
 	}
 	for _, tt := range tests {
-		if got := VersionAtLeast(tt.installed, tt.min); got != tt.want {
-			t.Errorf("VersionAtLeast(%q, %q) = %v, want %v", tt.installed, tt.min, got, tt.want)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			gotMin, gotMax := VersionInRange(tt.installed, tt.min, tt.max)
+			if gotMin != tt.wantMin || gotMax != tt.wantMax {
+				t.Errorf("VersionInRange(%q, %q, %q) = (%v, %v), want (%v, %v)",
+					tt.installed, tt.min, tt.max, gotMin, gotMax, tt.wantMin, tt.wantMax)
+			}
+		})
 	}
 }

--- a/internal/validations/validations.go
+++ b/internal/validations/validations.go
@@ -65,6 +65,12 @@ var (
 	libcryptoPrefix = "libcrypto.so"
 )
 
+var goFIPSMinVersion string
+
+func SetGoFIPSMinVersion(v string) {
+	goFIPSMinVersion = v
+}
+
 type Baton struct {
 	TopDir       string
 	Static       bool
@@ -154,10 +160,14 @@ func hasGodebugFIPS140Auto(baton *Baton) bool {
 func hasGOFIPS140Certified(baton *Baton) bool {
 	for _, bs := range baton.GoBuildInfo.Settings {
 		if bs.Key == "GOFIPS140" {
-			// GOFIPS140=certified resolves to a version string at build time
-			// (e.g. "v1.0.0-c2097c7c"), not the literal "certified". Any
-			// non-empty, non-"off" value indicates a FIPS module was selected.
-			return bs.Value != "" && bs.Value != "off"
+			if bs.Value == "" || bs.Value == "off" {
+				return false
+			}
+			if goFIPSMinVersion != "" {
+				atLeast, _ := types.VersionInRange(bs.Value, goFIPSMinVersion, "")
+				return atLeast
+			}
+			return true
 		}
 	}
 	return false

--- a/internal/validations/validations_host_crypto.go
+++ b/internal/validations/validations_host_crypto.go
@@ -16,47 +16,59 @@ import (
 )
 
 func CheckArtifact(ctx context.Context, m types.FipsModule, mountPath string) *types.ValidationError {
-	version, present := artifactPresentAndVersion(ctx, mountPath, m)
+	version, present := rpmPresentAndVersion(ctx, mountPath, m.CertifiedArtifact)
 	if !present {
-		klog.V(1).InfoS("fips artifact missing", "artifact", m.CertifiedArtifact, "module", m.Module, "mountPath", mountPath)
+		klog.V(1).InfoS("fips artifact RPM missing", "artifact", m.CertifiedArtifact, "module", m.Module)
 		return types.NewValidationError(fmt.Errorf("%s: %w", m.CertifiedArtifact, types.ErrFipsArtifactMissing))
 	}
-	if m.CertifiedArtifactMinVersion != "" && !types.VersionAtLeast(version, m.CertifiedArtifactMinVersion) {
-		installed := version
-		if installed == "" {
-			installed = "unknown (detected via file path, RPM not available)"
+	if version != "" {
+		atLeast, atMost := types.VersionInRange(version, m.CertifiedArtifactMinVersion, m.CertifiedArtifactMaxVersion)
+		if !atLeast {
+			klog.V(1).InfoS("fips artifact version too low", "artifact", m.CertifiedArtifact, "installed", version, "required", m.CertifiedArtifactMinVersion)
+			return types.NewValidationError(fmt.Errorf("%s (installed %s, need >= %s): %w",
+				m.CertifiedArtifact, version, m.CertifiedArtifactMinVersion, types.ErrFipsArtifactVersionLow))
 		}
-		klog.V(1).InfoS("fips artifact version too low", "artifact", m.CertifiedArtifact, "installed", installed, "required", m.CertifiedArtifactMinVersion)
-		return types.NewValidationError(fmt.Errorf("%s (installed %s, need >= %s): %w",
-			m.CertifiedArtifact, installed, m.CertifiedArtifactMinVersion, types.ErrFipsArtifactVersionLow))
+		if !atMost {
+			klog.V(1).InfoS("fips artifact version exceeds certified range", "artifact", m.CertifiedArtifact, "installed", version, "maxCertified", m.CertifiedArtifactMaxVersion)
+			return types.NewValidationError(fmt.Errorf("%s (installed %s, certified <= %s): %w",
+				m.CertifiedArtifact, version, m.CertifiedArtifactMaxVersion, types.ErrFipsArtifactVersionHigh))
+		}
+	}
+	if len(m.CertifiedArtifactPaths) > 0 && !anyPathExists(mountPath, m.CertifiedArtifactPaths) {
+		klog.V(1).InfoS("fips artifact RPM present but certified file missing", "artifact", m.CertifiedArtifact, "paths", m.CertifiedArtifactPaths)
+		return types.NewValidationError(fmt.Errorf("%s RPM present but certified file not found at %v: %w",
+			m.CertifiedArtifact, m.CertifiedArtifactPaths, types.ErrFipsArtifactMissing))
 	}
 	klog.V(1).InfoS("fips artifact present", "artifact", m.CertifiedArtifact, "version", version, "module", m.Module)
 	return nil
 }
 
-func artifactPresentAndVersion(ctx context.Context, mountPath string, m types.FipsModule) (version string, present bool) {
+func rpmPresentAndVersion(ctx context.Context, mountPath, rpmName string) (version string, present bool) {
 	rpms, err := rpm.GetAllRPMs(ctx, mountPath)
-	if err == nil {
-		for _, r := range rpms {
-			if r.Name == m.CertifiedArtifact {
-				v, err := rpm.VersionOf(ctx, mountPath, m.CertifiedArtifact)
-				if err == nil {
-					klog.V(1).InfoS("fips artifact found via RPM", "artifact", m.CertifiedArtifact, "version", v)
-					return v, true
-				}
-				klog.V(1).InfoS("fips artifact RPM found but version query failed", "artifact", m.CertifiedArtifact, "error", err)
-				return "", true
-			}
-		}
+	if err != nil {
+		return "", false
 	}
-	for _, p := range m.CertifiedArtifactPaths {
-		full := filepath.Join(mountPath, p)
-		if _, err := os.Stat(full); err == nil {
-			klog.V(1).InfoS("fips artifact found via file path", "artifact", m.CertifiedArtifact, "path", p)
+	for _, r := range rpms {
+		if r.Name == rpmName {
+			v, err := rpm.VersionOf(ctx, mountPath, rpmName)
+			if err == nil {
+				klog.V(1).InfoS("fips artifact found via RPM", "artifact", rpmName, "version", v)
+				return v, true
+			}
+			klog.V(1).InfoS("fips artifact RPM found but version query failed", "artifact", rpmName, "error", err)
 			return "", true
 		}
 	}
 	return "", false
+}
+
+func anyPathExists(mountPath string, paths []string) bool {
+	for _, p := range paths {
+		if _, err := os.Stat(filepath.Join(mountPath, p)); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 type hostLibCheck struct {
@@ -90,21 +102,35 @@ func findLib(mountPath string, searchPaths []string, subname string) (string, er
 	return "", fmt.Errorf("%s not found", subname)
 }
 
-// ValidateHostLibsForModules checks that each detected module's host library
-// exports FIPS symbols. Only modules registered in moduleHostLibChecks are
-// checked; modules without a host library (e.g. Go native FIPS) are skipped.
-func ValidateHostLibsForModules(ctx context.Context, mountPath string, modulesInUse map[string]bool) []*types.ValidationError {
-	var errs []*types.ValidationError
-	for module := range modulesInUse {
-		check, ok := moduleHostLibChecks[module]
-		if !ok {
-			continue
-		}
-		if ve := validateHostLib(ctx, mountPath, module, check); ve != nil {
-			errs = append(errs, ve)
+// ValidateModule performs unified FIPS validation for a single module.
+// Binary-source modules are skipped (validated during binary inspection).
+// Image-source modules try artifact check first, then fall back to host lib
+// FIPS symbol check. Passes if either succeeds.
+func ValidateModule(ctx context.Context, cfg *types.Config, mountPath string, module string) *types.ValidationError {
+	for _, r := range cfg.GetFIPSCertifiedModules() {
+		if r.Module == module && r.IsBinarySource() {
+			klog.V(1).InfoS("fips module validated at binary level, skipping image check", "module", module)
+			return nil
 		}
 	}
-	return errs
+
+	for _, r := range cfg.GetFIPSCertifiedModules() {
+		if r.Module != module || r.CertifiedArtifact == "" {
+			continue
+		}
+		klog.V(1).InfoS("checking fips artifact", "module", r.Module, "artifact", r.CertifiedArtifact)
+		if ve := CheckArtifact(ctx, r, mountPath); ve == nil {
+			return nil
+		}
+	}
+
+	if check, ok := moduleHostLibChecks[module]; ok {
+		if ve := validateHostLib(ctx, mountPath, module, check); ve == nil {
+			return nil
+		}
+	}
+
+	return types.NewValidationError(fmt.Errorf("no FIPS certified artifact or library found for module %s: %w", module, types.ErrFipsArtifactMissing))
 }
 
 func validateHostLib(ctx context.Context, mountPath, module string, check hostLibCheck) *types.ValidationError {

--- a/internal/validations/validations_native_fips_test.go
+++ b/internal/validations/validations_native_fips_test.go
@@ -57,21 +57,27 @@ func TestHasGodebugFIPS140Auto(t *testing.T) {
 
 func TestHasGOFIPS140Certified(t *testing.T) {
 	tests := []struct {
-		name     string
-		settings []debug.BuildSetting
-		want     bool
+		name       string
+		settings   []debug.BuildSetting
+		minVersion string
+		want       bool
 	}{
-		{"no GOFIPS140", nil, false},
-		{"GOFIPS140=off", []debug.BuildSetting{{Key: "GOFIPS140", Value: "off"}}, false},
-		{"GOFIPS140 empty", []debug.BuildSetting{{Key: "GOFIPS140", Value: ""}}, false},
-		{"GOFIPS140=latest", []debug.BuildSetting{{Key: "GOFIPS140", Value: "latest"}}, true},
-		{"GOFIPS140=v1.0.0", []debug.BuildSetting{{Key: "GOFIPS140", Value: "v1.0.0"}}, true},
-		{"GOFIPS140=v1.0.0-c2097c7c", []debug.BuildSetting{{Key: "GOFIPS140", Value: "v1.0.0-c2097c7c"}}, true},
-		{"GOFIPS140=certified", []debug.BuildSetting{{Key: "GOFIPS140", Value: "certified"}}, true},
-		{"GOFIPS140=inprocess", []debug.BuildSetting{{Key: "GOFIPS140", Value: "inprocess"}}, true},
+		{"no GOFIPS140", nil, "", false},
+		{"GOFIPS140=off", []debug.BuildSetting{{Key: "GOFIPS140", Value: "off"}}, "", false},
+		{"GOFIPS140 empty", []debug.BuildSetting{{Key: "GOFIPS140", Value: ""}}, "", false},
+		{"GOFIPS140=latest", []debug.BuildSetting{{Key: "GOFIPS140", Value: "latest"}}, "", true},
+		{"GOFIPS140=v1.0.0", []debug.BuildSetting{{Key: "GOFIPS140", Value: "v1.0.0"}}, "", true},
+		{"GOFIPS140=v1.0.0-c2097c7c", []debug.BuildSetting{{Key: "GOFIPS140", Value: "v1.0.0-c2097c7c"}}, "", true},
+		{"GOFIPS140=certified", []debug.BuildSetting{{Key: "GOFIPS140", Value: "certified"}}, "", true},
+		{"GOFIPS140=inprocess", []debug.BuildSetting{{Key: "GOFIPS140", Value: "inprocess"}}, "", true},
+		{"version >= min", []debug.BuildSetting{{Key: "GOFIPS140", Value: "v1.0.0"}}, "v1.0.0", true},
+		{"version < min", []debug.BuildSetting{{Key: "GOFIPS140", Value: "v0.9.0"}}, "v1.0.0", false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			old := goFIPSMinVersion
+			goFIPSMinVersion = tc.minVersion
+			defer func() { goFIPSMinVersion = old }()
 			baton := &Baton{GoBuildInfo: &debug.BuildInfo{Settings: tc.settings}}
 			if got := hasGOFIPS140Certified(baton); got != tc.want {
 				t.Errorf("got %v, want %v", got, tc.want)
@@ -226,7 +232,8 @@ func TestValidateGoNativeFIPS(t *testing.T) {
 func TestLegacyChecksSkippedForNativeFIPS(t *testing.T) {
 	ctx := context.Background()
 
-	baton := makeBaton("1.27.0",
+	baton := makeBaton(
+		"1.27.0",
 		debug.BuildSetting{Key: "DefaultGODEBUG", Value: "fips140=auto"},
 		debug.BuildSetting{Key: "GOFIPS140", Value: "v1.0.0-c2097c7c"},
 	)

--- a/internal/validations/validations_openssl_test.go
+++ b/internal/validations/validations_openssl_test.go
@@ -19,54 +19,36 @@ func createDirAndFile(t *testing.T, dir string) {
 	}
 }
 
-var testModule = types.FipsModule{
-	Module:            "openssl",
-	CertifiedArtifact: "openssl-fips-provider",
-	CertifiedArtifactPaths: []string{
-		"/usr/lib64/ossl-modules/fips.so",
-		"/usr/lib/ossl-modules/fips.so",
-	},
-}
+func TestAnyPathExists(t *testing.T) {
+	paths := []string{"/usr/lib64/ossl-modules/fips.so", "/usr/lib/ossl-modules/fips.so"}
 
-func TestArtifactPresent(t *testing.T) {
-	ctx := context.Background()
-
-	t.Run("no rpm db and no file path", func(t *testing.T) {
-		dir := t.TempDir()
-		_, present := artifactPresentAndVersion(ctx, dir, testModule)
-		if present {
-			t.Error("expected false when no db and no provider file")
-		}
-	})
-
-	t.Run("file path under lib64", func(t *testing.T) {
+	t.Run("file present at lib64", func(t *testing.T) {
 		dir := t.TempDir()
 		createDirAndFile(t, filepath.Join(dir, "usr", "lib64", "ossl-modules"))
-		_, present := artifactPresentAndVersion(ctx, dir, testModule)
-		if !present {
-			t.Error("expected true when file present at configured path")
+		if !anyPathExists(dir, paths) {
+			t.Error("expected true when file present")
 		}
 	})
 
-	t.Run("file path under lib", func(t *testing.T) {
+	t.Run("file present at lib", func(t *testing.T) {
 		dir := t.TempDir()
 		createDirAndFile(t, filepath.Join(dir, "usr", "lib", "ossl-modules"))
-		_, present := artifactPresentAndVersion(ctx, dir, testModule)
-		if !present {
-			t.Error("expected true when file present at configured path")
+		if !anyPathExists(dir, paths) {
+			t.Error("expected true when file present")
 		}
 	})
 
-	t.Run("no paths configured means file fallback skipped", func(t *testing.T) {
+	t.Run("file absent", func(t *testing.T) {
 		dir := t.TempDir()
-		createDirAndFile(t, filepath.Join(dir, "usr", "lib64", "ossl-modules"))
-		noPaths := types.FipsModule{
-			Module:            "openssl",
-			CertifiedArtifact: "openssl-fips-provider",
+		if anyPathExists(dir, paths) {
+			t.Error("expected false when no file present")
 		}
-		_, present := artifactPresentAndVersion(ctx, dir, noPaths)
-		if present {
-			t.Error("expected false when no paths configured and no RPM db")
+	})
+
+	t.Run("nil paths", func(t *testing.T) {
+		dir := t.TempDir()
+		if anyPathExists(dir, nil) {
+			t.Error("expected false for nil paths")
 		}
 	})
 }
@@ -74,31 +56,42 @@ func TestArtifactPresent(t *testing.T) {
 func TestCheckArtifact(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("artifact missing", func(t *testing.T) {
+	t.Run("RPM missing", func(t *testing.T) {
 		dir := t.TempDir()
-		err := CheckArtifact(ctx, testModule, dir)
-		if err == nil {
-			t.Error("expected error for missing artifact")
+		m := types.FipsModule{
+			Module:            "openssl",
+			CertifiedArtifact: "openssl-fips-provider",
+		}
+		if err := CheckArtifact(ctx, m, dir); err == nil {
+			t.Error("expected error when RPM missing")
 		}
 	})
 
-	t.Run("artifact present via file path", func(t *testing.T) {
+	t.Run("RPM missing even with paths present", func(t *testing.T) {
 		dir := t.TempDir()
 		createDirAndFile(t, filepath.Join(dir, "usr", "lib64", "ossl-modules"))
-		err := CheckArtifact(ctx, testModule, dir)
-		if err != nil {
-			t.Errorf("expected nil with artifact present, got %v", err)
+		m := types.FipsModule{
+			Module:                 "openssl",
+			CertifiedArtifact:      "openssl-fips-provider",
+			CertifiedArtifactPaths: []string{"/usr/lib64/ossl-modules/fips.so"},
+		}
+		if err := CheckArtifact(ctx, m, dir); err == nil {
+			t.Error("expected error: file exists but RPM not found")
 		}
 	})
 
-	t.Run("version required but unknown from file path", func(t *testing.T) {
+	t.Run("paths gate: RPM present but file missing fails", func(t *testing.T) {
 		dir := t.TempDir()
-		createDirAndFile(t, filepath.Join(dir, "usr", "lib64", "ossl-modules"))
-		m := testModule
-		m.CertifiedArtifactMinVersion = "3.0.7"
-		err := CheckArtifact(ctx, m, dir)
-		if err == nil {
-			t.Error("expected error when version required but unknown")
+		m := types.FipsModule{
+			Module:                 "openssl",
+			CertifiedArtifact:      "openssl-libs",
+			CertifiedArtifactPaths: []string{"/usr/lib64/ossl-modules/fips.so"},
+		}
+		// Can't mock RPM presence without rpmdb, so this tests the path
+		// gate in isolation via anyPathExists (tested above).
+		// CheckArtifact will fail at RPM check first.
+		if err := CheckArtifact(ctx, m, dir); err == nil {
+			t.Error("expected error when RPM missing")
 		}
 	})
 }

--- a/internal/validations/validations_os_test.go
+++ b/internal/validations/validations_os_test.go
@@ -2,34 +2,11 @@ package validations
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/openshift/check-payload/internal/types"
 )
-
-func setupFakeImage(t *testing.T, release string, providerPath string) string {
-	t.Helper()
-	dir := t.TempDir()
-	etc := filepath.Join(dir, "etc")
-	if err := os.MkdirAll(etc, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(etc, "redhat-release"), []byte(release), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if providerPath != "" {
-		full := filepath.Join(dir, providerPath)
-		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(full, nil, 0o644); err != nil {
-			t.Fatal(err)
-		}
-	}
-	return dir
-}
 
 func TestValidateModuleArtifacts(t *testing.T) {
 	ctx := context.Background()
@@ -42,64 +19,83 @@ func TestValidateModuleArtifacts(t *testing.T) {
 		}
 	}
 
-	opensslModule := types.FipsModule{
-		Module:            "openssl",
-		CertifiedArtifact: "openssl-fips-provider",
-		CertifiedArtifactPaths: []string{
-			"/usr/lib64/ossl-modules/fips.so",
-			"/usr/lib/ossl-modules/fips.so",
-		},
-	}
-
-	opensslModuleWithVersion := types.FipsModule{
-		Module:                      "openssl",
-		CertifiedArtifact:           "openssl-fips-provider",
-		CertifiedArtifactMinVersion: "3.0.7",
-		CertifiedArtifactPaths: []string{
-			"/usr/lib64/ossl-modules/fips.so",
-		},
-	}
-
 	t.Run("no modules in use returns nil", func(t *testing.T) {
 		dir := t.TempDir()
-		cfg := baseCfg([]types.FipsModule{opensslModule})
+		cfg := baseCfg([]types.FipsModule{
+			{Module: "openssl", CertifiedArtifact: "openssl-fips-provider"},
+		})
 		if ve := ValidateModuleArtifacts(ctx, cfg, dir, nil); ve != nil {
 			t.Errorf("expected nil, got %v", ve)
 		}
 	})
 
-	t.Run("module matched + provider present", func(t *testing.T) {
-		dir := setupFakeImage(t, "", "usr/lib64/ossl-modules/fips.so")
-		cfg := baseCfg([]types.FipsModule{opensslModule})
-		if ve := ValidateModuleArtifacts(ctx, cfg, dir, []string{"openssl"}); ve != nil {
-			t.Errorf("expected nil, got %v", ve)
-		}
-	})
-
-	t.Run("module matched + provider missing", func(t *testing.T) {
+	t.Run("module matched + RPM missing", func(t *testing.T) {
 		dir := t.TempDir()
-		cfg := baseCfg([]types.FipsModule{opensslModule})
+		cfg := baseCfg([]types.FipsModule{
+			{Module: "openssl", CertifiedArtifact: "openssl-fips-provider"},
+		})
 		ve := ValidateModuleArtifacts(ctx, cfg, dir, []string{"openssl"})
 		if ve == nil {
-			t.Error("expected error when provider missing")
-		}
-	})
-
-	t.Run("version required but unknown from file path", func(t *testing.T) {
-		dir := setupFakeImage(t, "", "usr/lib64/ossl-modules/fips.so")
-		cfg := baseCfg([]types.FipsModule{opensslModuleWithVersion})
-		ve := ValidateModuleArtifacts(ctx, cfg, dir, []string{"openssl"})
-		if ve == nil {
-			t.Error("expected error when version required but unknown")
+			t.Error("expected error when RPM missing")
 		}
 	})
 
 	t.Run("unmatched module returns nil", func(t *testing.T) {
 		dir := t.TempDir()
-		goModule := types.FipsModule{Module: "go", CertifiedArtifact: "go-std"}
-		cfg := baseCfg([]types.FipsModule{goModule})
+		cfg := baseCfg([]types.FipsModule{
+			{Module: "go", CertifiedArtifact: "go-std"},
+		})
 		if ve := ValidateModuleArtifacts(ctx, cfg, dir, []string{"openssl"}); ve != nil {
 			t.Errorf("expected nil when no config module matches, got %v", ve)
+		}
+	})
+}
+
+func TestValidateModule(t *testing.T) {
+	ctx := context.Background()
+
+	baseCfg := func(modules []types.FipsModule) *types.Config {
+		return &types.Config{
+			ConfigFile: types.ConfigFile{
+				FIPSCertifiedModules: modules,
+			},
+		}
+	}
+
+	t.Run("binary source skips image check", func(t *testing.T) {
+		dir := t.TempDir()
+		cfg := baseCfg([]types.FipsModule{
+			{Module: "go", ArtifactSource: "binary", CertifiedArtifact: "crypto/fips140"},
+		})
+		if ve := ValidateModule(ctx, cfg, dir, "go"); ve != nil {
+			t.Errorf("expected nil for binary source, got %v", ve)
+		}
+	})
+
+	t.Run("no artifact and no host lib fails", func(t *testing.T) {
+		dir := t.TempDir()
+		cfg := baseCfg([]types.FipsModule{
+			{
+				Module:            "openssl",
+				ArtifactSource:    "image",
+				CertifiedArtifact: "openssl-fips-provider",
+			},
+		})
+		if ve := ValidateModule(ctx, cfg, dir, "openssl"); ve == nil {
+			t.Error("expected error when no artifact and no host lib")
+		}
+	})
+
+	t.Run("anyPathExists gates CheckArtifact", func(t *testing.T) {
+		dir := t.TempDir()
+		paths := []string{"/usr/lib64/ossl-modules/fips.so"}
+
+		if anyPathExists(dir, paths) {
+			t.Error("expected false when fips.so absent")
+		}
+		createDirAndFile(t, filepath.Join(dir, "usr", "lib64", "ossl-modules"))
+		if !anyPathExists(dir, paths) {
+			t.Error("expected true when fips.so present")
 		}
 	})
 }


### PR DESCRIPTION
Replace separate artifact and host lib checks with unified per-module
ValidateModule that tries RPM + version range + file gate, then falls
back to host lib FIPS symbols. Adds certified_artifact_max_version to
scope entries to specific release lines (e.g. openssl-libs 1.1.1 for
RHEL 8). Config now declares all CMVP-certified modules explicitly.

Supports Go native FIPS via artifact_source="binary" with config-driven
minimum version for GOFIPS140 build setting.

Fixes: #332