### PR TITLE
Extend virt-launcher ErrNotDynLinked exception to new virt-launcher for nvidia

### DIFF
--- a/dist/releases/4.22/config.toml
+++ b/dist/releases/4.22/config.toml
@@ -485,6 +485,10 @@ files = ["/usr/bin/container-disk"]
 error = "ErrNotDynLinked"
 files = ["/usr/bin/container-disk"]
 
+[[payload.virt-launcher-4-nv-rhel10-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/bin/container-disk"]
+
 [[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = ["/usr/bin/cdi-containerimage-server"]

--- a/dist/releases/4.23/config.toml
+++ b/dist/releases/4.23/config.toml
@@ -485,6 +485,10 @@ files = ["/usr/bin/container-disk"]
 error = "ErrNotDynLinked"
 files = ["/usr/bin/container-disk"]
 
+[[payload.virt-launcher-4-nv-rhel10-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/bin/container-disk"]
+
 [[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = ["/usr/bin/cdi-containerimage-server"]

--- a/dist/releases/5.0/config.toml
+++ b/dist/releases/5.0/config.toml
@@ -485,6 +485,10 @@ files = ["/usr/bin/container-disk"]
 error = "ErrNotDynLinked"
 files = ["/usr/bin/container-disk"]
 
+[[payload.virt-launcher-4-nv-rhel10-container.ignore]]
+error = "ErrNotDynLinked"
+files = ["/usr/bin/container-disk"]
+
 [[payload.virt-cdi-importer-rhel9-container.ignore]]
 error = "ErrGoNotCgoEnabled"
 files = ["/usr/bin/cdi-containerimage-server"]


### PR DESCRIPTION
The new virt-launcher container that we produce is built like the original virt-launcher that we already have an exception approved for ErrNotDynLinked. The only difference is that it's based on rhel 10.2 to use a libvirt and qemu versions with nvidia patches.