### PR TITLE
ci: remove unused entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,5 @@ RUN wget -O /usr/local/bin/umoci "https://github.com/opencontainers/umoci/releas
 
 COPY --from=builder /app/check-payload /check-payload
 
-ENTRYPOINT ["/check-payload"]
+ENTRYPOINT []
 LABEL com.redhat.component="check-payload"


### PR DESCRIPTION
Partial addition #336 

entrypoint is unused in prow ci/konflux ci - removing to make simpler the ability to smoke test this when making changes