### PR TITLE
feat: add list-configs command to enumerate available OpenShift versions

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,6 +77,16 @@ func main() {
 		},
 	}
 
+	configsCmd := &cobra.Command{
+		Use:   "list-configs",
+		Short: "List available OpenShift version configurations",
+		Run: func(_ *cobra.Command, _ []string) {
+			for _, v := range releases.GetVersions() {
+				fmt.Println(v)
+			}
+		},
+	}
+
 	scanCmd := &cobra.Command{
 		Use:   "scan",
 		Short: "Run a scan",
@@ -284,6 +294,7 @@ func main() {
 	scanCmd.AddCommand(scanImage)
 
 	rootCmd.AddCommand(versionCmd)
+	rootCmd.AddCommand(configsCmd)
 	rootCmd.AddCommand(scanCmd)
 
 	// Add klog flags.


### PR DESCRIPTION
## Problem
The only way I found to discover which OpenShift version configurations are embedded in the binary is to force an error:

```bash
check-payload scan local -V bogus 2>&1 | grep 'use one of'
```

This requires parsing stderr, is fragile, and makes it difficult to integrate into CI pipelines or automation that needs to verify whether a target OpenShift version is supported before running a scan.

## Solution
Add a list-configs command that calls the existing GetVersions() function and prints each available version on its own line:

```bash
$ check-payload list-configs
4.9
4.10
...
5.0
```
This enables clean scripting patterns:

Get the latest supported version
```
check-payload list-configs | tail -1`
```

Check if a version is supported before scanning
```
if check-payload list-configs | grep -qx "4.17"; then
  check-payload scan payload -V 4.17 ...
fi
```
## Use case
In our automation we need to verify whether a container image targets a supported OpenShift version before running check-payload scans. Without this command, we had to force an error and parse the output — a pattern that is brittle and can break across versions.