### PR TITLE
RHAIENG-6078: Ignore ErrNotDynLinked for apply-seccomp on codeserver

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -268,16 +268,24 @@ files = ["/usr/local/bin/mta-cli"]
 #
 # ErrNotDynLinked ignores cite RHOAIENG-58626 (umbrella epic for multiple check-payload
 # FIPS findings across RHOAI). py-spy waivers: track RHOAIENG-58916. Work is broken
-# down by failing component/image in Jira. Pandoc rebuild/remediation: AIPCC-7795.
+# down by failing component/image in Jira. VS Code 1.112 apply-seccomp (sandbox-runtime):
+# RHAIENG-6078. Pandoc rebuild/remediation: AIPCC-7795.
 # -----------------------------------------------------------------------------
 
 # odh-workbench-codeserver-datascience-cpu-py312-rhel9
 [[payload.odh-workbench-codeserver-datascience-cpu-py312-rhel9.ignore]]
-# py-spy: track RHOAIENG-58916. rg (@vscode/ripgrep, IDE search): RHOAIENG-58626. Static upstream.
+# py-spy: track RHOAIENG-58916. rg (@vscode/ripgrep, IDE search): RHOAIENG-58626.
+# apply-seccomp: VS Code 1.112+ @anthropic-ai/sandbox-runtime seccomp BPF loaders;
+# statically linked, no cryptography, optional MCP/terminal sandbox only (RHAIENG-6078).
+# npm ships arm64/x64 only (no arch-specific variants for ppc64le/s390x image builds).
 error = "ErrNotDynLinked"
 files = [
     "/opt/app-root/bin/py-spy",
     "/usr/lib/code-server/lib/vscode/node_modules/@vscode/ripgrep/bin/rg",
+    "/usr/lib/code-server/lib/vscode/node_modules/@anthropic-ai/sandbox-runtime/dist/vendor/seccomp/arm64/apply-seccomp",
+    "/usr/lib/code-server/lib/vscode/node_modules/@anthropic-ai/sandbox-runtime/dist/vendor/seccomp/x64/apply-seccomp",
+    "/usr/lib/code-server/lib/vscode/node_modules/@anthropic-ai/sandbox-runtime/vendor/seccomp/arm64/apply-seccomp",
+    "/usr/lib/code-server/lib/vscode/node_modules/@anthropic-ai/sandbox-runtime/vendor/seccomp/x64/apply-seccomp",
 ]
 
 # odh-workbench-jupyter-datascience-cpu-py312-rhel9


### PR DESCRIPTION
## Summary

Follow-up to #327. Adds a payload-scoped `ErrNotDynLinked` exception for **codeserver only** so Konflux/FBC `check-payload` scans pass while FIPS checks remain enabled.

### codeserver ([RHAIENG-6078](https://redhat.atlassian.net/browse/RHAIENG-6078))

VS Code 1.112 (code-server v4.112.0) ships statically linked `apply-seccomp` helpers from `@anthropic-ai/sandbox-runtime`. These are seccomp BPF loaders with **no cryptographic operations** — optional MCP/terminal sandbox tooling only.

Waive under `payload.odh-workbench-codeserver-datascience-cpu-py312-rhel9` via explicit `files` paths (same style as `rg` and `py-spy` in #327). The npm package ships **four** binaries (arm64 + x64 under both `dist/vendor/seccomp` and `vendor/seccomp`); there are no ppc64le/s390x variants, so Konflux multi-arch builds still scan the bundled arm64/x64 paths.

```
/usr/lib/code-server/lib/vscode/node_modules/@anthropic-ai/sandbox-runtime/dist/vendor/seccomp/arm64/apply-seccomp
/usr/lib/code-server/lib/vscode/node_modules/@anthropic-ai/sandbox-runtime/dist/vendor/seccomp/x64/apply-seccomp
/usr/lib/code-server/lib/vscode/node_modules/@anthropic-ai/sandbox-runtime/vendor/seccomp/arm64/apply-seccomp
/usr/lib/code-server/lib/vscode/node_modules/@anthropic-ai/sandbox-runtime/vendor/seccomp/x64/apply-seccomp
```

## Tracking

| Binary | Jira | Action |
|--------|------|--------|
| apply-seccomp (4 paths) | [RHAIENG-6078](https://redhat.atlassian.net/browse/RHAIENG-6078) | **This PR** — codeserver `files` waiver |

## Test plan

- [x] `make test` passes locally
- [x] config.toml validates (pre-commit hook)
- [ ] OpenShift CI after `/ok-to-test`
- [ ] After merge: bump embedded `check-payload` in `quay.io/konflux-ci/konflux-test`