### PR TITLE
FROM scratch data-only image containing skill definition files so the…

### DIFF
--- a/dist/releases/5.0/config.toml
+++ b/dist/releases/5.0/config.toml
@@ -574,3 +574,8 @@ files = [
 [[tag.rhel-coreos-10.ignore]]
 error = "ErrOSNotCertified"
 tags = ["rhel-coreos-10"]
+# agentic-skills is a FROM scratch data-only container with no OS layer;
+# OS-level FIPS validation is not applicable.
+[[tag.agentic-skills.ignore]]
+error = "ErrOSNotCertified"
+tags = ["agentic-skills"]


### PR DESCRIPTION
…re's no OS layer thus FIPS OS validatioin is not applicable

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

https://redhat-internal.slack.com/archives/CB95J6R4N/p1785445793383609