### PR TITLE
ci: go and lint bump

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"image": "golang:1.24",
+	"image": "golang:1.26",
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,25 @@
-# For documentation, see https://golangci-lint.run/usage/configuration/
+version: "2"
 
-run:
-  timeout: 5m
+# For documentation, see https://golangci-lint.run/usage/configuration/
 
 linters:
   enable:
-    - gofumpt
     - errorlint
     - unconvert
     - unparam
     - revive
+  exclusions:
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - path: internal/types/
+        linters:
+          - revive
+        text: "var-naming: avoid meaningless package names"
+
+formatters:
+  enable:
+    - gofumpt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,8 @@ The `verify` target includes:
 
 - `verify-space`: Ensures no trailing whitespace
 - `verify-generate`: Verifies `go generate ./internal/types` is up to date
-- `verify-golangci`: Runs golangci-lint with configured linters (gofumpt, errorlint, unconvert, unparam, revive)
+- `verify-golangci`: Runs golangci-lint with configured linters (errorlint, unconvert, unparam, revive)
+- `verify-fmt`: Runs `golangci-lint fmt --diff` to enforce configured formatters (gofumpt) without rewriting files
 
 All checks must pass before submitting PRs.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
 
 WORKDIR /app
 

--- a/Dockerfile.upstream
+++ b/Dockerfile.upstream
@@ -1,4 +1,4 @@
-FROM golang:1.24 as builder
+FROM golang:1.26 as builder
 
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all:
 	CGO_ENABLED=0 $(GO) build -ldflags="-X main.Commit=$$(git describe --tags --abbrev=8 --dirty --always --long)"
 
 .PHONY: verify
-verify: verify-space verify-generate verify-golangci
+verify: verify-space verify-generate verify-golangci verify-fmt
 
 .PHONY: test
 test:
@@ -14,6 +14,10 @@ test:
 .PHONY: verify-golangci
 verify-golangci:
 	golangci-lint run
+
+.PHONY: verify-fmt
+verify-fmt: ## Ensure code is formatted per configured formatters (gofumpt)
+	golangci-lint fmt --diff
 
 .PHONY: verify-space
 verify-space: ## Ensure no whitespace at EOL

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/check-payload
 
-go 1.24.0
+go 1.26.0
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/internal/types/types_config.go
+++ b/internal/types/types_config.go
@@ -140,11 +140,11 @@ func (i ErrIgnoreList) IgnoreTag(tag string, err error) bool {
 }
 
 func (c *Config) GetCertifiedDistributions() []string {
-	return c.ConfigFile.CertifiedDistributions
+	return c.CertifiedDistributions
 }
 
 func (c *Config) GetFIPSCertifiedModules() []FipsModule {
-	return c.ConfigFile.FIPSCertifiedModules
+	return c.FIPSCertifiedModules
 }
 
 func (c *Config) UseFIPSModuleValidation() bool {


### PR DESCRIPTION
bumping go and lint versions - need to sync with [openshift/release](https://github.com/openshift/release/pull/82933)