### PR TITLE
fix(scan): classify missing release file and add --tag to local scans

### DIFF
--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -130,7 +130,7 @@ func RunLocalScan(ctx context.Context, cfg *types.Config, localBundlePath string
 	var runs []*types.ScanResults
 
 	// Simulate payload based on local directory structure
-	localPayload := simulateLocalPayload(localBundlePath)
+	localPayload := simulateLocalPayload(localBundlePath, cfg.LocalTag)
 
 	// Rest of the function follows the structure of RunPayloadScan
 	parallelism := cfg.Parallelism
@@ -180,18 +180,16 @@ func scanLocal(ctx context.Context, cfg *types.Config, tx <-chan *Request, rx ch
 	}
 }
 
-// simulateLocalPayload generates a slice of v1.TagReference based on the local bundle directory structure.
-// Adjust this to match how your local bundle's tags are represented in the file system if needed
-func simulateLocalPayload(localBundlePath string) []*v1.TagReference {
-	// Placeholder: mock implementation to avoid linter warning about always returning nil
-	// Replace with actual logic when ready
+// simulateLocalPayload generates a slice of v1.TagReference for the local
+// bundle. The optional tagName carries the release image tag identity so
+// tag-scoped config exceptions can match; it does not affect path resolution.
+func simulateLocalPayload(localBundlePath, tagName string) []*v1.TagReference {
 	if localBundlePath == "" {
 		return nil
 	}
 
-	// Example: Create a mock tag reference
 	mockTag := &v1.TagReference{
-		Name: "",
+		Name: tagName,
 		From: &corev1.ObjectReference{
 			Name: "",
 		},
@@ -329,8 +327,11 @@ func validateTag(ctx context.Context, tag *v1.TagReference, cfg *types.Config) *
 
 // validateTagLocal adapts validateTag for a local directory path.
 func validateTagLocal(ctx context.Context, tag *v1.TagReference, cfg *types.Config, bundlePath string) *types.ScanResults {
-	// Determine the path within the local bundle that corresponds to the tag.
-	localTagPath := filepath.Join(bundlePath, tag.Name)
+	// The tag only carries identity (for tag-scoped config exceptions);
+	// the bundle path is the scan root regardless of tag name. Clean keeps
+	// the pre-tag behavior of filepath.Join (e.g. strips trailing slashes
+	// so stripMountPath yields absolute inner paths).
+	localTagPath := filepath.Clean(bundlePath)
 
 	// Verify the path exists and is a directory.
 	fileInfo, err := os.Stat(localTagPath)

--- a/internal/scan/scan_test.go
+++ b/internal/scan/scan_test.go
@@ -2,6 +2,9 @@ package scan
 
 import (
 	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -140,6 +143,112 @@ func TestRunLocalScan(t *testing.T) {
 				t.Errorf("Test %s: expected pass = %t, got pass = %t", tc.name, tc.expectedResult, passed)
 			}
 		})
+	}
+}
+
+// TestRunLocalScanDataOnlyImage covers FROM-scratch data-only images (no OS
+// layer, no binaries): without tag identity the scan fails with
+// ErrDistributionFileMissing; with --tag and a matching tag ignore the OS
+// validation is skipped.
+func TestRunLocalScanDataOnlyImage(t *testing.T) {
+	tagIgnoredOsConfig := func(localTag string) *types.Config {
+		return &types.Config{
+			OutputFormat: "table",
+			Parallelism:  1,
+			TimeLimit:    30 * time.Second,
+			LocalTag:     localTag,
+			ConfigFile: types.ConfigFile{
+				PayloadIgnores: make(map[string]types.IgnoreLists),
+				TagIgnores: map[string]types.IgnoreLists{
+					"agentic-skills": {
+						ErrIgnores: types.ErrIgnoreList{{
+							Error: types.KnownError{Err: types.ErrOSNotCertified},
+							Tags:  []string{"agentic-skills"},
+						}},
+					},
+				},
+				RPMIgnores:             make(map[string]types.IgnoreLists),
+				CertifiedDistributions: []string{"Red Hat Enterprise Linux release 9.2 (Plow)"},
+			},
+		}
+	}
+
+	t.Run("no tag fails with ErrDistributionFileMissing", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		results := RunLocalScan(ctx, tagIgnoredOsConfig(""), t.TempDir())
+		if !IsFailed(results) {
+			t.Fatal("expected scan to fail without tag identity")
+		}
+		var found bool
+		for _, run := range results {
+			for _, res := range run.Items {
+				if res.Error != nil && errors.Is(res.Error.GetError(), types.ErrDistributionFileMissing) {
+					found = true
+				}
+			}
+		}
+		if !found {
+			t.Error("expected ErrDistributionFileMissing in results")
+		}
+	})
+
+	t.Run("matching tag ignore skips OS validation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		results := RunLocalScan(ctx, tagIgnoredOsConfig("agentic-skills"), t.TempDir())
+		if IsFailed(results) {
+			t.Error("expected scan to pass with matching tag ignore")
+		}
+	})
+
+	t.Run("non-matching tag still fails", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		results := RunLocalScan(ctx, tagIgnoredOsConfig("other-tag"), t.TempDir())
+		if !IsFailed(results) {
+			t.Error("expected scan to fail for non-matching tag")
+		}
+	})
+}
+
+// TestRunLocalScanTagDoesNotChangeScanRoot pins the --tag semantics: the tag
+// carries identity only. The scan root stays --path; it is never resolved to
+// a <path>/<tag> subdirectory.
+func TestRunLocalScanTagDoesNotChangeScanRoot(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "etc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	release := []byte("Red Hat Enterprise Linux release 9.2 (Plow)")
+	if err := os.WriteFile(filepath.Join(root, "etc", "redhat-release"), release, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &types.Config{
+		OutputFormat: "table",
+		Parallelism:  1,
+		TimeLimit:    30 * time.Second,
+		LocalTag:     "some-tag",
+		ConfigFile: types.ConfigFile{
+			PayloadIgnores:         make(map[string]types.IgnoreLists),
+			TagIgnores:             make(map[string]types.IgnoreLists),
+			RPMIgnores:             make(map[string]types.IgnoreLists),
+			CertifiedDistributions: []string{string(release)},
+		},
+	}
+
+	// No <root>/some-tag subdirectory exists: if the tag were joined into
+	// the scan root, the scan would fail on a missing directory.
+	results := RunLocalScan(ctx, cfg, root)
+	if IsFailed(results) {
+		t.Error("expected scan rooted at --path to pass; a failure suggests the tag was joined into the scan root")
 	}
 }
 

--- a/internal/scan/scan_test.go
+++ b/internal/scan/scan_test.go
@@ -148,8 +148,8 @@ func TestRunLocalScan(t *testing.T) {
 
 // TestRunLocalScanDataOnlyImage covers FROM-scratch data-only images (no OS
 // layer, no binaries): without tag identity the scan fails with
-// ErrDistributionFileMissing; with --tag and a matching tag ignore the OS
-// validation is skipped.
+// ErrDistributionFileMissing; with --tag and a matching tag ignore the scan
+// skips OS validation.
 func TestRunLocalScanDataOnlyImage(t *testing.T) {
 	tagIgnoredOsConfig := func(localTag string) *types.Config {
 		return &types.Config{
@@ -216,8 +216,8 @@ func TestRunLocalScanDataOnlyImage(t *testing.T) {
 }
 
 // TestRunLocalScanTagDoesNotChangeScanRoot pins the --tag semantics: the tag
-// carries identity only. The scan root stays --path; it is never resolved to
-// a <path>/<tag> subdirectory.
+// carries identity only. The scan root stays --path; the scanner never
+// resolves it to a <path>/<tag> subdirectory.
 func TestRunLocalScanTagDoesNotChangeScanRoot(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -244,11 +244,11 @@ func TestRunLocalScanTagDoesNotChangeScanRoot(t *testing.T) {
 		},
 	}
 
-	// No <root>/some-tag subdirectory exists: if the tag were joined into
-	// the scan root, the scan would fail on a missing directory.
+	// No <root>/some-tag subdirectory exists: if the scanner joined the tag
+	// into the scan root, the scan would fail on a missing directory.
 	results := RunLocalScan(ctx, cfg, root)
 	if IsFailed(results) {
-		t.Error("expected scan rooted at --path to pass; a failure suggests the tag was joined into the scan root")
+		t.Error("expected scan rooted at --path to pass; a failure suggests the scanner joined the tag into the scan root")
 	}
 }
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -42,6 +42,7 @@ type Config struct {
 	FromURL                 string        `json:"from_url"`
 	InsecurePull            bool          `json:"insecure_pull"`
 	Limit                   int           `json:"limit"`
+	LocalTag                string        `json:"local_tag"`
 	ContainerImageComponent string        `json:"container_image_component"`
 	ContainerImage          string        `json:"container_image"`
 	OutputFile              string        `json:"output_file"`

--- a/internal/validations/validations_os.go
+++ b/internal/validations/validations_os.go
@@ -27,17 +27,13 @@ func ValidateOS(cfg *types.Config, mountPath string) (info types.OSInfo) {
 
 	path, err := GetTargetPath(mountPath)
 	if err != nil {
-		info.Error = types.NewValidationError(err)
+		info.Error = classifyReleaseFileError(err)
 		return info
 	}
 
 	f, err := os.ReadFile(path)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			info.Error = types.NewValidationError(types.ErrDistributionFileMissing)
-		} else {
-			info.Error = types.NewValidationError(err)
-		}
+		info.Error = classifyReleaseFileError(err)
 		return info
 	}
 	if len(f) == 0 {
@@ -52,6 +48,15 @@ func ValidateOS(cfg *types.Config, mountPath string) (info types.OSInfo) {
 		}
 	}
 	return info
+}
+
+// classifyReleaseFileError maps a missing release file (from either Lstat or
+// ReadFile) to ErrDistributionFileMissing so config exceptions can match it.
+func classifyReleaseFileError(err error) *types.ValidationError {
+	if errors.Is(err, os.ErrNotExist) {
+		return types.NewValidationError(types.ErrDistributionFileMissing)
+	}
+	return types.NewValidationError(err)
 }
 
 // ValidateModuleArtifacts checks that each detected module's certified

--- a/internal/validations/validations_os_test.go
+++ b/internal/validations/validations_os_test.go
@@ -2,11 +2,116 @@ package validations
 
 import (
 	"context"
+	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/openshift/check-payload/internal/types"
 )
+
+func TestValidateOS(t *testing.T) {
+	certified := []string{"Red Hat Enterprise Linux release 9.6 (Plow)"}
+
+	cfgWith := func(distributions []string) *types.Config {
+		return &types.Config{
+			ConfigFile: types.ConfigFile{
+				CertifiedDistributions: distributions,
+			},
+		}
+	}
+
+	writeReleaseFile := func(t *testing.T, root, content string) {
+		t.Helper()
+		etc := filepath.Join(root, "etc")
+		if err := os.MkdirAll(etc, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(etc, "redhat-release"), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tests := []struct {
+		name          string
+		setup         func(t *testing.T, root string)
+		distributions []string
+		wantErr       error
+		wantWarning   bool
+		wantCertified bool
+	}{
+		{
+			name:          "missing release file classified as ErrDistributionFileMissing",
+			setup:         func(*testing.T, string) {},
+			distributions: certified,
+			wantErr:       types.ErrDistributionFileMissing,
+		},
+		{
+			name: "dangling symlink classified as ErrDistributionFileMissing",
+			setup: func(t *testing.T, root string) {
+				etc := filepath.Join(root, "etc")
+				if err := os.MkdirAll(etc, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink("/usr/lib/system-release", filepath.Join(etc, "redhat-release")); err != nil {
+					t.Fatal(err)
+				}
+			},
+			distributions: certified,
+			wantErr:       types.ErrDistributionFileMissing,
+		},
+		{
+			name: "certified distribution",
+			setup: func(t *testing.T, root string) {
+				writeReleaseFile(t, root, "Red Hat Enterprise Linux release 9.6 (Plow)")
+			},
+			distributions: certified,
+			wantCertified: true,
+		},
+		{
+			name: "uncertified distribution",
+			setup: func(t *testing.T, root string) {
+				writeReleaseFile(t, root, "Fedora release 42 (Adams)")
+			},
+			distributions: certified,
+		},
+		{
+			name:          "empty certified distributions warns",
+			setup:         func(*testing.T, string) {},
+			distributions: nil,
+			wantErr:       types.ErrCertifiedDistributionsEmpty,
+			wantWarning:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			tc.setup(t, root)
+
+			info := ValidateOS(cfgWith(tc.distributions), root)
+
+			if tc.wantErr != nil {
+				if info.Error == nil {
+					t.Fatalf("expected error %v, got nil", tc.wantErr)
+				}
+				if !errors.Is(info.Error.GetError(), tc.wantErr) {
+					t.Errorf("expected error %v, got %v", tc.wantErr, info.Error.GetError())
+				}
+				if gotWarning := info.Error.Level == types.Warning; gotWarning != tc.wantWarning {
+					t.Errorf("expected warning=%v, got level %v", tc.wantWarning, info.Error.Level)
+				}
+				return
+			}
+			if info.Error != nil {
+				t.Fatalf("expected no error, got %v", info.Error)
+			}
+			if info.Certified != tc.wantCertified {
+				t.Errorf("expected certified=%v, got %v", tc.wantCertified, info.Certified)
+			}
+		})
+	}
+}
 
 func TestValidateModuleArtifacts(t *testing.T) {
 	ctx := context.Background()

--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ var (
 	timeLimit                             time.Duration
 	verbose                               bool
 	localBundlePath                       string
+	localTag                              string
 )
 
 func main() {
@@ -219,11 +220,13 @@ func main() {
 		Run: func(_ *cobra.Command, _ []string) {
 			ctx, cancel := context.WithTimeout(context.Background(), config.TimeLimit)
 			defer cancel()
+			config.LocalTag = localTag
 			results = scan.RunLocalScan(ctx, &config, localBundlePath)
 		},
 	}
 
 	localCmd.Flags().StringVar(&localBundlePath, "path", "", "Path to the local unpacked image bundle")
+	localCmd.Flags().StringVar(&localTag, "tag", "", "Release image tag name the local bundle was unpacked from, enables tag-scoped config exceptions")
 
 	// Add the 'local' subcommand to 'scanCmd'
 	scanCmd.AddCommand(localCmd)


### PR DESCRIPTION
## Summary

- Classify a missing `/etc/redhat-release` detected via `Lstat` as
  `ErrDistributionFileMissing` instead of leaking a raw lstat error that no
  config exception can match (previously only the `ReadFile` path was
  classified).
- Add a `--tag` flag to `scan local` so tag-scoped config exceptions (e.g.
  `[[tag.agentic-skills.ignore]]`) can apply. Local scans previously used an
  empty mock tag name, making every tag ignore unreachable. The tag carries
  identity only — the scan root remains `--path` and is never resolved to a
  `<path>/<tag>` subdirectory (pinned by test).
- Fixes the `payload-scan-5-0` smoke test failure on the `agentic-skills`
  FROM-scratch data-only image: no OS layer, zero binaries, and the existing
  `ErrOSNotCertified` tag ignore could not fire under `scan local`.

Without `--tag`, behavior is unchanged: the mock tag name stays empty, no
ignores match, and the scan root normalization (`filepath.Clean`) is identical
to the previous `filepath.Join(path, "")`.

Companion openshift/release change passes the tag name per image in the
`payload-scan-*` steps; this PR must merge first since old binaries reject the
new flag.
