### PR TITLE
Add exception for ripgrep-universal in Dev Spaces Code

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -252,6 +252,36 @@ error = "ErrNotDynLinked"
 files = ["/usr/local/bin/mta-cli"]
 
 # -----------------------------------------------------------------------------
+# Dev Spaces Code (devspaces-code-rhel9-container)
+#
+# ripgrep (BurntSushi/ripgrep) is a text search tool used by VS Code for
+# workspace search. It does not perform any cryptographic operations.
+# Binary inspection confirmed zero references to OpenSSL, libcrypto, FIPS APIs,
+# or any cipher/TLS primitives — only false positives from Unicode script codes
+# and Rust Thread-Local Storage symbols.
+#
+# @vscode/ripgrep — original single-platform package (legacy, kept for
+# backward compatibility with older builds).
+# @vscode/ripgrep-universal — new all-platform bundle introduced upstream;
+# non-target platform binaries are stripped at VS Code packaging time.
+# See: https://github.com/microsoft/vscode/commit/c4471e2
+# -----------------------------------------------------------------------------
+[[payload.devspaces-code-rhel9-container.ignore]]
+error = "ErrNotDynLinked"
+files = [
+  "/checode-linux-libc/ubi8/node_modules/@vscode/ripgrep/bin/rg",
+  "/checode-linux-libc/ubi9/node_modules/@vscode/ripgrep/bin/rg",
+  "/checode-linux-libc/ubi8/node_modules/@vscode/ripgrep-universal/bin/linux-x64/rg",
+  "/checode-linux-libc/ubi9/node_modules/@vscode/ripgrep-universal/bin/linux-x64/rg",
+  "/checode-linux-libc/ubi8/node_modules/@vscode/ripgrep-universal/bin/linux-arm64/rg",
+  "/checode-linux-libc/ubi9/node_modules/@vscode/ripgrep-universal/bin/linux-arm64/rg",
+  "/checode-linux-libc/ubi8/node_modules/@vscode/ripgrep-universal/bin/linux-ppc64/rg",
+  "/checode-linux-libc/ubi9/node_modules/@vscode/ripgrep-universal/bin/linux-ppc64/rg",
+  "/checode-linux-libc/ubi8/node_modules/@vscode/ripgrep-universal/bin/linux-s390x/rg",
+  "/checode-linux-libc/ubi9/node_modules/@vscode/ripgrep-universal/bin/linux-s390x/rg",
+]
+
+# -----------------------------------------------------------------------------
 # Open Data Hub (ODH) / RHOAI payloads: odh-workbench-* and odh-pipeline-runtime-*
 #
 # odh-workbench-* images are interactive JupyterLab and code-server workbenches.

--- a/dist/releases/4.15/config.toml
+++ b/dist/releases/4.15/config.toml
@@ -207,10 +207,3 @@ files = ["/usr/bin/container-disk"]
 [[payload.openshift-istio-kiali-operator-container.ignore]]
 error = "ErrNotDynLinked"
 files = ["/usr/libexec/catatonit/catatonit"]
-
-[[payload.devspaces-code-rhel9-container.ignore]]
-error = "ErrNotDynLinked"
-files = [
-  "/checode-linux-libc/ubi8/node_modules/@vscode/ripgrep/bin/rg",
-  "/checode-linux-libc/ubi9/node_modules/@vscode/ripgrep/bin/rg"
-]

--- a/dist/releases/4.16/config.toml
+++ b/dist/releases/4.16/config.toml
@@ -487,10 +487,3 @@ files = ["/usr/bin/container-disk"]
 [[payload.virt-launcher-rhel9-container.ignore]]
 error = "ErrNotDynLinked"
 files = ["/usr/bin/container-disk"]
-
-[[payload.devspaces-code-rhel9-container.ignore]]
-error = "ErrNotDynLinked"
-files = [
-  "/checode-linux-libc/ubi8/node_modules/@vscode/ripgrep/bin/rg",
-  "/checode-linux-libc/ubi9/node_modules/@vscode/ripgrep/bin/rg"
-]

--- a/dist/releases/4.17/config.toml
+++ b/dist/releases/4.17/config.toml
@@ -507,10 +507,3 @@ files = ["/usr/bin/container-disk"]
 [[payload.virt-launcher-rhel9-container.ignore]]
 error = "ErrNotDynLinked"
 files = ["/usr/bin/container-disk"]
-
-[[payload.devspaces-code-rhel9-container.ignore]]
-error = "ErrNotDynLinked"
-files = [
-  "/checode-linux-libc/ubi8/node_modules/@vscode/ripgrep/bin/rg",
-  "/checode-linux-libc/ubi9/node_modules/@vscode/ripgrep/bin/rg"
-]

--- a/dist/releases/4.18/config.toml
+++ b/dist/releases/4.18/config.toml
@@ -531,10 +531,3 @@ files = [
   "/usr/sbin/build-locale-archive",
   "/usr/sbin/ldconfig"
 ]
-
-[[payload.devspaces-code-rhel9-container.ignore]]
-error = "ErrNotDynLinked"
-files = [
-  "/checode-linux-libc/ubi8/node_modules/@vscode/ripgrep/bin/rg",
-  "/checode-linux-libc/ubi9/node_modules/@vscode/ripgrep/bin/rg"
-]

--- a/dist/releases/4.19/config.toml
+++ b/dist/releases/4.19/config.toml
@@ -553,10 +553,3 @@ files = [
   "/usr/local/bin/kubevirt.test",
   "/usr/local/bin/ssp.test"
 ]
-
-[[payload.devspaces-code-rhel9-container.ignore]]
-error = "ErrNotDynLinked"
-files = [
-  "/checode-linux-libc/ubi8/node_modules/@vscode/ripgrep/bin/rg",
-  "/checode-linux-libc/ubi9/node_modules/@vscode/ripgrep/bin/rg"
-]

--- a/dist/releases/4.20/config.toml
+++ b/dist/releases/4.20/config.toml
@@ -553,10 +553,3 @@ files = [
   "/usr/local/bin/kubevirt.test",
   "/usr/local/bin/ssp.test"
 ]
-
-[[payload.devspaces-code-rhel9-container.ignore]]
-error = "ErrNotDynLinked"
-files = [
-  "/checode-linux-libc/ubi8/node_modules/@vscode/ripgrep/bin/rg",
-  "/checode-linux-libc/ubi9/node_modules/@vscode/ripgrep/bin/rg"
-]

--- a/dist/releases/4.21/config.toml
+++ b/dist/releases/4.21/config.toml
@@ -554,13 +554,6 @@ files = [
   "/usr/local/bin/ssp.test"
 ]
 
-[[payload.devspaces-code-rhel9-container.ignore]]
-error = "ErrNotDynLinked"
-files = [
-  "/checode-linux-libc/ubi8/node_modules/@vscode/ripgrep/bin/rg",
-  "/checode-linux-libc/ubi9/node_modules/@vscode/ripgrep/bin/rg"
-]
-
 # In 4.21 and 4.22 we'll have a rhel-coreos-10 and rhel-coreos-10-extensions image
 # these images are devpreview / techpreview and thus not beholden to FIPS validation
 # TODO: revisit this after 4.22 branch

--- a/dist/releases/4.22/config.toml
+++ b/dist/releases/4.22/config.toml
@@ -559,13 +559,6 @@ files = [
   "/usr/local/bin/ssp.test"
 ]
 
-[[payload.devspaces-code-rhel9-container.ignore]]
-error = "ErrNotDynLinked"
-files = [
-  "/checode-linux-libc/ubi8/node_modules/@vscode/ripgrep/bin/rg",
-  "/checode-linux-libc/ubi9/node_modules/@vscode/ripgrep/bin/rg"
-]
-
 # In 4.21 and 4.22 we'll have a rhel-coreos-10 and rhel-coreos-10-extensions image
 # these images are devpreview / techpreview and thus not beholden to FIPS validation
 [[tag.rhel-coreos-10.ignore]]

--- a/dist/releases/4.23/config.toml
+++ b/dist/releases/4.23/config.toml
@@ -563,13 +563,6 @@ files = [
   "/usr/local/bin/ssp.test"
 ]
 
-[[payload.devspaces-code-rhel9-container.ignore]]
-error = "ErrNotDynLinked"
-files = [
-  "/checode-linux-libc/ubi8/node_modules/@vscode/ripgrep/bin/rg",
-  "/checode-linux-libc/ubi9/node_modules/@vscode/ripgrep/bin/rg"
-]
-
 # In 4.23 we have a rhel-coreos-10 image
 # this image is devpreview / techpreview and thus not beholden to FIPS validation
 [[tag.rhel-coreos-10.ignore]]

--- a/dist/releases/5.0/config.toml
+++ b/dist/releases/5.0/config.toml
@@ -563,13 +563,6 @@ files = [
   "/usr/local/bin/ssp.test"
 ]
 
-[[payload.devspaces-code-rhel9-container.ignore]]
-error = "ErrNotDynLinked"
-files = [
-  "/checode-linux-libc/ubi8/node_modules/@vscode/ripgrep/bin/rg",
-  "/checode-linux-libc/ubi9/node_modules/@vscode/ripgrep/bin/rg"
-]
-
 # FIPS status is non blocker for RHCOS10 in 5.0
 [[tag.rhel-coreos-10.ignore]]
 error = "ErrOSNotCertified"

--- a/dist/releases/5.1/config.toml
+++ b/dist/releases/5.1/config.toml
@@ -563,13 +563,6 @@ files = [
   "/usr/local/bin/ssp.test"
 ]
 
-[[payload.devspaces-code-rhel9-container.ignore]]
-error = "ErrNotDynLinked"
-files = [
-  "/checode-linux-libc/ubi8/node_modules/@vscode/ripgrep/bin/rg",
-  "/checode-linux-libc/ubi9/node_modules/@vscode/ripgrep/bin/rg"
-]
-
 # FIPS status is non blocker for RHCOS10 in 5.0
 [[tag.rhel-coreos-10.ignore]]
 error = "ErrOSNotCertified"


### PR DESCRIPTION
## Context
-  Dev Spaces has an exception for `@vscode/ripgrep`, see https://github.com/openshift/check-payload/pull/284
- Starting with Dev Spaces `3.30`, the upstream VS Code replaced `@vscode/ripgrep` with `@vscode/ripgrep-universal` as a production dependency.

`@vscode/ripgrep-universal` is a new package from the same repository (microsoft/vscode-ripgrep) that bundles ripgrep (BurntSushi/ripgrep) binaries for all platforms in a single tarball, eliminating the `postinstall` download step.
Non-target platform binaries are stripped at VS Code packaging time.
See: https://github.com/microsoft/vscode/commit/c4471e24faf21ae50af048d09d68cb6e3092e4ad

The binary path changed from `node_modules/@vscode/ripgrep/bin/rg` to `node_modules/@vscode/ripgrep-universal/bin/<platform>-<arch>/rg`.

## Justification

ripgrep (BurntSushi/ripgrep) is a text search tool. It does not perform cryptographic operations.

Verified by inspecting the binaries in the container image `quay.io/redhat-user-workloads/devspaces-tenant/devspaces/code-rhel9:3.30` across all four architectures (amd64, arm64, s390x, ppc64le):
- `strings <binary> | grep -iE` with word-boundary matching found only false positives:
  "rsa" as a Unicode script code (ISO 15924) embedded in Rust's regex engine,  "TLS" referring to Thread-Local Storage in Rust runtime
- Zero matches for actual cryptographic APIs or libraries: openssl, libssl, libcrypto, fips, cipher, encrypt, decrypt, EVP_*, PKCS, x509, certificate, hmac
  
## Changes

- Adds `@vscode/ripgrep-universal` paths for all supported architectures (linux-x64, linux-arm64, linux-ppc64, linux-s390x) and both UBI variants (ubi8, ubi9) to the `devspaces-code-rhel9-container` exception in releases:
4.16, 4.18, 4.19, 4.20, 4.21, 4.22, 4.23, 5.0, 5.1.
- The old `@vscode/ripgrep/bin/rg` paths are preserved for backward compatibility.